### PR TITLE
chore: initialize Claude Code agent environment for HackForger

### DIFF
--- a/.claude/agents/codebase-navigator.md
+++ b/.claude/agents/codebase-navigator.md
@@ -1,0 +1,56 @@
+---
+name: codebase-navigator
+description: Scans the HackForger/Forgejo codebase and produces a focused code map for the current task. Use this before starting any feature implementation to understand relevant modules and avoid context overload.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+# Codebase Navigator
+
+You are a code architecture analyst for HackForger (a Forgejo fork). Your job is to scan the codebase and produce a **focused code map** -- only the files and functions relevant to the current task.
+
+## Process
+
+1. Understand the task description
+2. Identify which HackForger modules are involved (hackathon/bounty/grants/credits/feed/reputation)
+3. Scan the relevant directories:
+   - `models/hackforger/` for data models
+   - `services/hackforger/` for business logic
+   - `routers/api/v1/hackforger/` for API endpoints
+   - `routers/web/hackforger/` for web routes
+   - `templates/hackforger/` for UI templates
+   - `web_src/js/features/hackforger/` for Vue components
+4. If the task touches Forgejo native features, also scan:
+   - `models/repo/`, `models/issues/`, `models/org/` -- for understanding existing models
+   - `services/repository/`, `services/issue/` -- for reuse patterns
+   - `routers/web/repo/`, `routers/api/v1/repo/` -- for routing patterns
+5. Produce a code map in this format:
+
+```
+## Code Map: [Task Name]
+
+### Directly Relevant Files
+- `models/hackforger/bounty.go` -- Bounty struct, BountyStatus enum
+  - CreateBounty(), GetBountyByIssueID(), UpdateBounty()
+- `services/hackforger/bounty.go` -- Business logic
+  - OnPullRequestMerged() -- PR merge hook, triggers status change
+  - OnBountyCompleted() -- Credits distribution
+
+### Forgejo Files to Reference (read-only)
+- `models/issues/issue.go` -- Issue struct (Bounty 1:1 binds to Issue)
+- `services/pull/merge.go` -- PR merge flow, need to add hook here
+
+### Files to Create/Modify
+- `services/hackforger/bounty.go` -- Add new function: ...
+- `templates/hackforger/bounty/issue_panel.tmpl` -- Create new template
+
+### Not Relevant (skip these)
+- `models/hackforger/hackathon.go` -- Not needed for this task
+- `services/hackforger/grants.go` -- Not needed
+```
+
+## Rules
+- NEVER include the entire Forgejo codebase. Only map what's needed.
+- For large files, list only the relevant functions, not the entire file.
+- Always check if a Forgejo native function already does what we need before suggesting new code.
+- Flag any Forgejo files in the "11 injection points" list that this task might need to modify.

--- a/.claude/agents/forgejo-dev.md
+++ b/.claude/agents/forgejo-dev.md
@@ -1,0 +1,33 @@
+---
+name: forgejo-dev
+description: Expert in Forgejo's Go codebase patterns. Use for implementing HackForger features following Forgejo's architectural conventions.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: opus
+---
+
+# Forgejo Development Expert
+
+You are an expert Go developer specializing in Forgejo's architecture. When implementing HackForger features:
+
+## Architecture Rules
+1. **Layer discipline**: routers -> services -> models -> modules. Never import upward.
+2. **XORM patterns**: Use `xorm:"pk autoincr"` tags. Register tables in `models/hackforger/init.go`.
+3. **Error handling**: Return typed errors (e.g., `ErrBountyNotFound`), not generic errors.
+4. **Context propagation**: Always pass `context.Context` as first parameter.
+5. **Database transactions**: Use `db.WithTx(ctx, func(ctx context.Context) error { ... })` for multi-table operations.
+6. **Feed events**: Every state change must call `PublishHackforgerAction()`.
+7. **API style**: Follow Forgejo's existing patterns in `routers/api/v1/repo/`. JSON tags on all struct fields. Swagger comments on all handlers.
+8. **Template style**: Use Go template syntax `{{.Field}}`, `{{range .Items}}`, `{{if .Condition}}`. CSS uses Tailwind classes.
+
+## Common Patterns Reference
+- Creating a new model: See `models/issues/issue.go` for struct + CRUD pattern
+- Creating a new API endpoint: See `routers/api/v1/repo/issue.go` for handler pattern
+- Creating a new web route: See `routers/web/repo/issue.go` for page handler pattern
+- Service with notifications: See `services/issue/issue.go` for notification pattern
+- Cron task: See `services/cron/tasks.go` for registration pattern
+
+## Don'ts
+- Don't use `tea` CLI. Use `gh` for GitHub operations.
+- Don't create Forgejo Actions (`.forgejo/workflows/`) for the GitHub repo. Use GitHub Actions (`.github/workflows/`) instead.
+- Don't use React or any framework other than Vue 3 for frontend components.
+- Don't add external Go dependencies without justification. Forgejo is conservative on deps.

--- a/.claude/commands/api-test.md
+++ b/.claude/commands/api-test.md
@@ -1,0 +1,20 @@
+---
+description: Test a HackForger API endpoint against the internal instance
+allowed-tools: Bash
+---
+Test an API endpoint on the internal HackForger instance.
+
+Usage: /api-test METHOD /path [JSON body]
+Example: /api-test GET /hackforger/hackathons
+Example: /api-test POST /hackforger/hackathons '{"name":"test"}'
+
+Execute:
+```bash
+curl -s -X $METHOD \
+  -H "Authorization: token $FORGEJO_TOKEN" \
+  -H "Content-Type: application/json" \
+  ${BODY:+-d "$BODY"} \
+  "https://hackforger.inside.h2os.cloud/api/v1$PATH" | jq .
+```
+
+If FORGEJO_TOKEN is not set, warn the user to set it first.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,11 @@
+---
+description: Build HackForger (backend, frontend, or both)
+allowed-tools: Bash
+---
+Build the project. Arguments: "backend", "frontend", "all" (default: all)
+
+If "$ARGUMENTS" is "backend": run `make backend`
+If "$ARGUMENTS" is "frontend": run `make frontend`
+Otherwise: run `make build`
+
+Report any compilation errors clearly.

--- a/.claude/commands/codemap.md
+++ b/.claude/commands/codemap.md
@@ -1,0 +1,7 @@
+---
+description: Generate a focused code map for a task
+allowed-tools: Read, Grep, Glob
+---
+Use the codebase-navigator agent to scan the codebase and produce a focused code map for: $ARGUMENTS
+
+Output the map showing only relevant files, functions, and Forgejo injection points needed.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,16 @@
+---
+description: Run HackForger tests
+allowed-tools: Bash, Read, Grep
+---
+Run tests. Arguments: module name or "all"
+
+If "$ARGUMENTS" is "all":
+  Run `go test ./models/hackforger/... ./services/hackforger/... -v -count=1`
+
+If "$ARGUMENTS" is a module name (bounty, hackathon, grants, credits, reputation, feed):
+  Run `go test ./models/hackforger/... ./services/hackforger/... -v -run "Test.*${ARGUMENTS}" -count=1`
+
+If "$ARGUMENTS" is "e2e":
+  Run `go test ./tests/integration/... -v -tags='sqlite sqlite_unlock_notify' -run TestE2E`
+
+Report results with pass/fail summary.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,8 @@
     "agent-browser@agent-setup": true,
     "skill-creator@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "learning-output-style@claude-plugins-official": true
+    "learning-output-style@claude-plugins-official": true,
+    "ui-ux-pro-max@ui-ux-pro-max-skill": true
   },
   "hooks": {
     "PreToolUse": [
@@ -40,5 +41,13 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "ui-ux-pro-max-skill": {
+      "source": {
+        "source": "github",
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill"
+      }
+    }
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "enabledPlugins": {
+    "agent-setup@agent-setup": true,
+    "superpowers@agent-setup": true,
+    "agent-browser@agent-setup": true,
+    "skill-creator@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "learning-output-style@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "intercept",
+            "pattern": "\\btea\\s+(issue|pr|repo|release|login)",
+            "message": "Please use `gh` instead of `tea`. tea is the Forgejo/Codeberg CLI; we develop on GitHub. Equivalent commands: gh issue / gh pr / gh repo. For API calls use `curl` with GITHUB_TOKEN or FORGEJO_TOKEN."
+          },
+          {
+            "type": "intercept",
+            "pattern": "codeberg\\.org/(Synnovator|HackForge)",
+            "message": "The project is hosted on GitHub, not Codeberg. Correct address: github.com/HackForger/hackforger"
+          },
+          {
+            "type": "intercept",
+            "pattern": "hackforge\\.inside\\.h2os\\.cloud",
+            "message": "The internal instance address has changed to hackforger.inside.h2os.cloud (with 'r'). Please update the URL."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "intercept",
+            "pattern": "models/(repo|issues|org|user|actions|auth)/",
+            "message": "You are modifying an upstream Forgejo model file. HackForger's new code should go in models/hackforger/. If you must modify an upstream file, confirm it is one of the 11 injection points listed in implementation-plan-draft.md."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/frontend-design.md
+++ b/.claude/skills/frontend-design.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,12 @@ prime/
 
 # Manpage
 /man
+
+# Agent Setup runtime (gitignored)
+.agents/
+
+# User-local launcher overrides
+claude.local.sh
+
+# MCP server secrets (API keys, tokens)
+.mcp.env

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "forgejo": {
+      "command": "forgejo-mcp",
+      "args": [
+        "--transport", "stdio",
+        "--url", "https://hackforger.inside.h2os.cloud"
+      ],
+      "env": {
+        "FORGEJO_ACCESS_TOKEN": "${FORGEJO_TOKEN}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/context7-mcp"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# HackForger Development Guide
+
+## Project Overview
+HackForger is a Fork of Forgejo, adding Hackathon, Bounty, Grant, Credits, and Feed modules.
+All new code lives in `*/hackforger/` directories, minimizing changes to upstream Forgejo files.
+
+- Upstream: https://codeberg.org/forgejo/forgejo
+- Project repo: https://github.com/HackForger/hackforger
+- Internal instance: https://hackforger.inside.h2os.cloud
+- Primary dev tool: Claude Code
+
+## Architecture Rules
+- Forgejo uses strict layered architecture: routers -> services -> models -> modules
+- Upper layers may only call lower layers, never the reverse
+- New Go package paths: `forgejo.org/models/hackforger/`, `forgejo.org/services/hackforger/`, etc.
+- Database: XORM ORM, define Go struct + tags for auto table creation
+- Frontend: Go template SSR + partial Vue 3 component enhancement (not SPA)
+
+## Directory Structure
+- `models/hackforger/` -- Data models (15 tables)
+- `services/hackforger/` -- Business logic
+- `routers/api/v1/hackforger/` -- REST API
+- `routers/web/hackforger/` -- Web page routes
+- `templates/hackforger/` -- Go HTML templates
+- `modules/hackforger/feed/` -- Feed event type definitions
+- `web_src/js/features/hackforger/` -- Vue components
+
+## Naming Conventions
+- Go files: snake_case (hackathon.go, bounty_reward.go)
+- Go structs: CamelCase (HackathonSubmission, BountyReward)
+- API paths: kebab-case (/api/v1/hackforger/grant-rounds)
+- Template files: snake_case (judge_panel.tmpl)
+- Vue components: PascalCase (BountyPanel.vue)
+
+## Common Commands
+- `make backend` -- Compile backend
+- `make frontend` -- Compile frontend
+- `go test ./models/hackforger/... -v` -- Run model tests
+- `go test ./services/hackforger/... -v` -- Run service tests
+- `./gitea web` -- Start server (http://localhost:3000)
+
+## Important Constraints
+- Use `gh` CLI for GitHub operations (not `tea` -- that's for Codeberg/Forgejo)
+- Do not modify upstream Forgejo files unless listed in the 11 injection points (see implementation-plan-draft.md section 1.2)
+- All state changes must call PublishHackforgerAction to write Feed events
+- Credits Deposit/Redeem must use db.WithTx transactions
+- Internal HackForger instance: https://hackforger.inside.h2os.cloud
+- API base path: https://hackforger.inside.h2os.cloud/api/v1/hackforger/
+
+## CI/CD
+- Primary CI: GitHub Actions (`.github/workflows/`)
+- Self-hosted instance CI: Forgejo Actions (`.forgejo/workflows/`) -- kept for self-deployed HackForger instances
+- Do not create Forgejo Actions for the GitHub-hosted repo
+
+## Environment Variables
+- `GITHUB_TOKEN` -- For gh CLI and GitHub API
+- `FORGEJO_TOKEN` -- For self-hosted HackForger instance API
+- `FORGEJO_URL` -- https://hackforger.inside.h2os.cloud
+
+## Git Remotes
+- `origin` -- git@github.com:HackForger/hackforger.git (our repo)
+- `upstream` -- https://codeberg.org/forgejo/forgejo.git (Forgejo upstream, read-only)

--- a/claude.sh
+++ b/claude.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+# ============================================
+# Claude Code launcher
+#
+# All modes run inside tmux for:
+#   - SSH disconnect resilience (session keeps running)
+#   - Seamless reattach from any terminal (./claude.sh)
+#
+# Modes:
+#   [1] Interactive          — standard claude session
+#   [2] Interactive+Worktree — isolated git branch for feature work
+#   [3] Remote Control       — continue from phone/browser
+# ============================================
+
+# Source shell configuration for proper PATH setup
+if [ -f "$HOME/.zprofile" ]; then
+    source "$HOME/.zprofile" 2>/dev/null
+fi
+if [ -f "$HOME/.zshrc" ]; then
+    export ZDOTDIR_BACKUP="$ZDOTDIR"
+    source "$HOME/.zshrc" 2>/dev/null
+fi
+if [ -f "$HOME/.bash_profile" ]; then
+    source "$HOME/.bash_profile" 2>/dev/null
+fi
+if [ -f "$HOME/.bashrc" ]; then
+    source "$HOME/.bashrc" 2>/dev/null
+fi
+
+# Ensure common paths are included as fallback (Homebrew on Apple Silicon / Intel, npm global)
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source user-local overrides (proxy, API keys, etc.)
+[ -f "$SCRIPT_DIR/claude.local.sh" ] && source "$SCRIPT_DIR/claude.local.sh"
+
+# Source MCP server secrets (API keys, tokens)
+[ -f "$SCRIPT_DIR/.mcp.env" ] && set -a && source "$SCRIPT_DIR/.mcp.env" && set +a
+
+# Get project name from directory (sanitize for tmux session name)
+PROJECT_NAME=$(basename "$SCRIPT_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g')
+
+# Session prefix for this project
+SESSION_PREFIX="claude-${PROJECT_NAME}"
+
+# ============================================
+# Pre-flight checks
+# ============================================
+
+if ! command -v claude &> /dev/null; then
+    echo "❌ claude command not found!"
+    echo ""
+    echo "PATH: $PATH"
+    echo ""
+    echo "Please install Claude Code first:"
+    echo "  npm install -g @anthropic-ai/claude-code"
+    exit 1
+fi
+
+if ! command -v tmux &> /dev/null; then
+    echo "❌ tmux not found!"
+    echo ""
+    echo "Please install tmux first:"
+    echo "  brew install tmux"
+    exit 1
+fi
+
+# ============================================
+# Agent Setup plugin bootstrap
+# ============================================
+
+if ! claude plugin list 2>/dev/null | grep -q "agent-setup@agent-setup"; then
+    echo "📦 Installing agent-setup plugin..."
+    claude plugin install agent-setup@agent-setup --scope project 2>/dev/null || {
+        echo "⚠️  Could not install agent-setup plugin. Run manually:"
+        echo "  claude plugin install agent-setup@agent-setup --scope project"
+    }
+    echo ""
+fi
+
+# ============================================
+# Flags per mode
+#
+# Interactive: supports --permission-mode, --mcp-config, --worktree
+# Remote Control: only supports --verbose, --sandbox, --no-sandbox
+# Permission mode is also set in .claude/settings.json (defaultMode)
+# so remote-control sessions inherit it without needing a CLI flag.
+# ============================================
+
+INTERACTIVE_FLAGS="--permission-mode bypassPermissions"
+
+if [ -f "$SCRIPT_DIR/.claude/mcp.json" ]; then
+    INTERACTIVE_FLAGS="$INTERACTIVE_FLAGS --mcp-config .claude/mcp.json"
+fi
+
+RC_FLAGS=""
+
+# ============================================
+# iTerm2 detection → tmux -CC (native integration)
+#
+# tmux -CC makes iTerm2 render tmux windows/panes as native
+# tabs and splits. Scrolling, copy/paste, resizing all work
+# natively. Over SSH, set SendEnv LC_TERMINAL in ~/.ssh/config
+# on the client, and AcceptEnv LC_* in sshd_config on the server.
+#
+# Override: CLAUDE_TMUX_CLASSIC=1 ./claude.sh  (force plain tmux)
+# ============================================
+
+TMUX_CC=""
+if [ "${CLAUDE_TMUX_CLASSIC:-}" != "1" ]; then
+    if [ "$TERM_PROGRAM" = "iTerm.app" ] || \
+       [ "$LC_TERMINAL" = "iTerm2" ] || \
+       [ -n "$ITERM_SESSION_ID" ]; then
+        TMUX_CC="-CC"
+    fi
+fi
+
+# ============================================
+# Shared: mode selection menu
+# ============================================
+
+show_mode_menu() {
+    echo "  [1] Interactive (Recommended)"
+    echo "  [2] Interactive + Worktree — isolated git branch"
+    echo "  [3] Remote Control — continue from phone/browser"
+}
+
+# ============================================
+# Outside tmux: session management + mode selection
+# ============================================
+
+if [ -z "$TMUX" ]; then
+
+    echo "📂 Project: $(basename "$SCRIPT_DIR")"
+    echo "📍 Directory: $SCRIPT_DIR"
+    if [ -n "$TMUX_CC" ]; then
+        echo "🍎 iTerm2 detected — using native tmux integration (tmux -CC)"
+    fi
+    echo ""
+
+    # --- Check for existing sessions first ---
+    EXISTING_SESSIONS=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E "^${SESSION_PREFIX}" || true)
+
+    # Helper: attach to a session, detaching other clients by default
+    # so window size adapts to the current terminal (not the old one).
+    # tmux -CC (iTerm2) handles sizing independently, so skip -d.
+    tmux_attach() {
+        local target="$1"
+        if [ -n "$TMUX_CC" ]; then
+            exec tmux -CC attach -t "$target"
+        else
+            exec tmux attach -dt "$target"
+        fi
+    }
+
+    if [ -n "$EXISTING_SESSIONS" ]; then
+        SESSION_COUNT=$(echo "$EXISTING_SESSIONS" | wc -l | tr -d ' ')
+
+        if [ "$SESSION_COUNT" -eq 1 ]; then
+            INFO=$(tmux list-sessions -F '#{session_name}: #{session_windows} windows (created #{t:session_created})' 2>/dev/null | grep "^$EXISTING_SESSIONS:")
+            CLIENTS=$(tmux list-clients -t "$EXISTING_SESSIONS" -F '#{client_name}' 2>/dev/null | wc -l | tr -d ' ')
+
+            echo "📌 Found existing session: $INFO"
+            if [ "$CLIENTS" -gt 0 ]; then
+                echo "   ⚡ $CLIENTS client(s) currently attached (will be detached)"
+            fi
+            echo ""
+            read -p "Attach to this session? [Y/n] " -n 1 -r
+            echo ""
+
+            if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+                tmux_attach "$EXISTING_SESSIONS"
+            fi
+            echo ""
+        else
+            echo "📌 Found multiple sessions for project '$PROJECT_NAME':"
+            echo ""
+            i=1
+            declare -a SESSION_ARRAY
+            while IFS= read -r session; do
+                INFO=$(tmux list-sessions -F '#{session_name}: #{session_windows} windows (created #{t:session_created})' 2>/dev/null | grep "^$session:")
+                CLIENTS=$(tmux list-clients -t "$session" -F '#{client_name}' 2>/dev/null | wc -l | tr -d ' ')
+                ATTACHED=""
+                if [ "$CLIENTS" -gt 0 ]; then
+                    ATTACHED=" ⚡${CLIENTS} attached"
+                fi
+                echo "  [$i] $INFO$ATTACHED"
+                SESSION_ARRAY[$i]="$session"
+                ((i++))
+            done <<< "$EXISTING_SESSIONS"
+            echo "  [n] Create new session"
+            echo ""
+            read -p "Select session [1]: " -r CHOICE
+
+            if [[ "$CHOICE" =~ ^[Nn]$ ]]; then
+                : # Fall through to create new session
+            elif [ -z "$CHOICE" ] || [ "$CHOICE" = "1" ]; then
+                tmux_attach "${SESSION_ARRAY[1]}"
+            elif [[ "$CHOICE" =~ ^[0-9]+$ ]] && [ "$CHOICE" -le "${#SESSION_ARRAY[@]}" ]; then
+                tmux_attach "${SESSION_ARRAY[$CHOICE]}"
+            else
+                echo "Invalid choice, attaching to first session"
+                tmux_attach "${SESSION_ARRAY[1]}"
+            fi
+            echo ""
+        fi
+    fi
+
+    # --- Mode selection ---
+    echo "Create new session:"
+    show_mode_menu
+    echo ""
+    read -p "Mode [1]: " -r MODE
+    MODE=${MODE:-1}
+
+    if [ "$MODE" != "1" ] && [ "$MODE" != "2" ] && [ "$MODE" != "3" ]; then
+        echo "❌ Invalid mode: $MODE"
+        exit 1
+    fi
+
+    # --- Prompt for session name ---
+    UUID_SHORT=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    case "$MODE" in
+        1)
+            DEFAULT_NAME="${SESSION_PREFIX}-$(date +%m%d)-${UUID_SHORT}"
+            echo ""
+            echo "Enter a session name."
+            ;;
+        2)
+            DEFAULT_NAME="${SESSION_PREFIX}-$(date +%m%d)-${UUID_SHORT}"
+            echo ""
+            echo "Enter a session name (also used as worktree branch name)."
+            echo "Examples: ${SESSION_PREFIX}-feat-auth, ${SESSION_PREFIX}-bugfix-login"
+            ;;
+        3)
+            DEFAULT_NAME="${SESSION_PREFIX}-rc-$(date +%m%d)-${UUID_SHORT}"
+            echo ""
+            echo "Enter a session name for the remote control session."
+            ;;
+    esac
+    echo ""
+    read -p "Session name [$DEFAULT_NAME]: " -r SESSION_NAME
+    SESSION_NAME=${SESSION_NAME:-$DEFAULT_NAME}
+    echo ""
+
+    # --- Enable tmux passthrough for iTerm2 escape sequences ---
+    # Allows notifications (e.g., zchat notify_command) to reach
+    # the outer terminal (iTerm2) through tmux, even over SSH.
+    tmux set-option -g allow-passthrough on 2>/dev/null
+
+    # --- Create tmux session (all modes go through tmux) ---
+    echo "🚀 Creating tmux session: $SESSION_NAME"
+    exec tmux $TMUX_CC new-session -s "$SESSION_NAME" "cd '$SCRIPT_DIR' && '$0' --_internal '$MODE' '$SESSION_NAME'"
+fi
+
+# ============================================
+# Inside tmux: run Claude Code
+# ============================================
+
+cd "$SCRIPT_DIR"
+
+CURRENT_SESSION=$(tmux display-message -p '#S')
+echo "✅ Running in tmux session: $CURRENT_SESSION"
+echo "📂 Working directory: $(pwd)"
+echo ""
+
+# Parse internal arguments (passed from outer invocation)
+RUN_MODE=""
+SESSION_NAME=""
+if [ "$1" = "--_internal" ]; then
+    RUN_MODE="${2:-}"
+    SESSION_NAME="${3:-}"
+fi
+
+# If no internal args, user ran ./claude.sh from a new tmux window — ask interactively
+if [ -z "$RUN_MODE" ]; then
+    echo "New session in existing tmux:"
+    show_mode_menu
+    echo ""
+    read -p "Mode [1]: " -r RUN_MODE
+    RUN_MODE=${RUN_MODE:-1}
+
+    if [ "$RUN_MODE" != "1" ] && [ "$RUN_MODE" != "2" ] && [ "$RUN_MODE" != "3" ]; then
+        echo "❌ Invalid mode: $RUN_MODE"
+        exit 1
+    fi
+
+    UUID_SHORT=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    case "$RUN_MODE" in
+        1)
+            # No extra name needed for simple interactive
+            SESSION_NAME=""
+            ;;
+        2)
+            DEFAULT_NAME="${SESSION_PREFIX}-$(date +%m%d)-${UUID_SHORT}"
+            echo ""
+            echo "Enter a worktree/branch name."
+            echo "Examples: feat-auth, bugfix-login, refactor-api"
+            echo ""
+            read -p "Name [$DEFAULT_NAME]: " -r SESSION_NAME
+            SESSION_NAME=${SESSION_NAME:-$DEFAULT_NAME}
+            ;;
+        3)
+            DEFAULT_NAME="rc-$(date +%m%d)-${UUID_SHORT}"
+            echo ""
+            echo "Enter a session label."
+            echo ""
+            read -p "Name [$DEFAULT_NAME]: " -r SESSION_NAME
+            SESSION_NAME=${SESSION_NAME:-$DEFAULT_NAME}
+            ;;
+    esac
+    echo ""
+fi
+
+echo "💡 Tips:"
+echo "   - Reattach after disconnect: ./claude.sh"
+if [ -n "$TMUX_CC" ]; then
+    echo "   (iTerm2 native integration active)"
+    echo "   - New tab:     Cmd+T"
+    echo "   - Split horiz: Cmd+Shift+D"
+    echo "   - Split vert:  Cmd+D"
+    echo "   - Switch pane: Cmd+[ / Cmd+]"
+    echo "   - Close pane:  Cmd+W"
+    echo "   - Scroll:      mouse/trackpad (native)"
+    echo "   - Copy/paste:  Cmd+C / Cmd+V"
+    echo "   - Detach:      close iTerm2 window (session keeps running)"
+else
+    echo "   - Detach (keep running): Ctrl+b, d"
+    echo "   - New window: Ctrl+b, c  →  ./claude.sh"
+    echo "   - Split pane: Ctrl+b, %  or  Ctrl+b, \""
+    echo "   - Switch pane/window: Ctrl+b, arrow / Ctrl+b, n/p"
+    echo "   - Zoom pane:  Ctrl+b, z"
+    echo "   - Scroll mode: Ctrl+b, [  (exit: q)"
+fi
+echo ""
+
+# --- Mode 1: Interactive (standard) ---
+if [ "$RUN_MODE" = "1" ]; then
+    echo "🔧 Mode: Interactive"
+    echo ""
+    claude $INTERACTIVE_FLAGS
+
+# --- Mode 2: Interactive + Worktree ---
+elif [ "$RUN_MODE" = "2" ]; then
+    echo "🔧 Mode: Interactive + Worktree"
+    echo ""
+    if [ -n "$SESSION_NAME" ]; then
+        claude --worktree "$SESSION_NAME" $INTERACTIVE_FLAGS
+    else
+        claude --worktree $INTERACTIVE_FLAGS
+    fi
+
+# --- Mode 3: Remote Control ---
+elif [ "$RUN_MODE" = "3" ]; then
+    echo "🌐 Mode: Remote Control"
+    echo "   Connect from: claude.ai/code or Claude mobile app"
+    echo "   Press spacebar to show QR code for mobile"
+    echo ""
+    claude remote-control $RC_FLAGS
+fi
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "⚠️  Claude exited with code: $EXIT_CODE"
+fi
+echo ""
+echo "Session ended. Press any key to close, or Ctrl+b d to keep tmux session."
+read -n 1

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,23 @@
+*.inside.h2os.cloud {
+	tls {
+		dns alidns {
+			access_key_id {env.ALIDNS_ACCESS_KEY_ID}
+			access_key_secret {env.ALIDNS_ACCESS_KEY_SECRET}
+		}
+	}
+
+	@hackforger host hackforger.inside.h2os.cloud
+	handle @hackforger {
+		reverse_proxy host.docker.internal:3000
+	}
+
+	# Add more services here:
+	# @another host another.inside.h2os.cloud
+	# handle @another {
+	#     reverse_proxy host.docker.internal:8080
+	# }
+
+	handle {
+		respond "Service not configured" 404
+	}
+}

--- a/deploy/caddy/Dockerfile
+++ b/deploy/caddy/Dockerfile
@@ -1,0 +1,8 @@
+FROM caddy:2-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/alidns
+
+FROM caddy:2-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,662 @@
+# HackForger 开发环境配置
+
+> HackForger = Fork of Forgejo + HackForger 模块（Hackathon / Bounty / Grant / Credits / Feed）
+> 上游仓库: https://codeberg.org/forgejo/forgejo
+> 项目仓库: https://github.com/HackForger/hackforger
+> 内网实例: https://hackforger.inside.h2os.cloud
+> 主力开发工具: Claude Code
+
+---
+
+## 一、代码 Fork 与仓库配置
+
+### 1.1 初始 Fork（在 GitHub 上操作）
+
+```bash
+# 方式 A：通过 GitHub Web UI Fork
+# 访问 https://codeberg.org/forgejo/forgejo → 在本地 clone 后推送到 GitHub
+
+# 方式 B：通过命令行
+git clone https://codeberg.org/forgejo/forgejo.git hackforger
+cd hackforger
+
+# 查看最新稳定 tag
+git tag --sort=-v:refname | head -5
+
+# 基于最新稳定版创建主分支
+git checkout -b main v12.0.1  # 替换为实际最新 tag
+
+# 配置 remote
+git remote rename origin upstream
+git remote add origin git@github.com:HackForger/hackforger.git
+
+# 推送
+git push -u origin main
+```
+
+### 1.2 Remote 配置
+
+```bash
+git remote -v
+# origin    git@github.com:HackForger/hackforger.git (fetch)
+# origin    git@github.com:HackForger/hackforger.git (push)
+# upstream  https://codeberg.org/forgejo/forgejo.git (fetch)
+# upstream  https://codeberg.org/forgejo/forgejo.git (push)
+```
+
+### 1.3 分支策略
+
+```
+main                        ← 稳定分支，基于上游 tag
+├── develop                 ← 日常开发
+│   ├── feat/bounty         ← 线 A
+│   ├── feat/hackathon      ← 线 B
+│   └── feat/grants-credits ← 线 C
+└── upstream/forgejo        ← 跟踪上游（只读）
+```
+
+### 1.4 同步上游
+
+```bash
+git fetch upstream --tags
+git checkout -b sync/v12.1.0 v12.1.0
+git cherry-pick <our-commits>    # 不 rebase，cherry-pick 我们的 commit
+git checkout main && git merge sync/v12.1.0
+git push origin main
+```
+
+---
+
+## 二、开发环境：本地直装
+
+Claude Code 在终端中运行，不需要 VS Code 或 DevContainer。直接在宿主机装依赖。
+
+### 2.1 依赖安装
+
+```bash
+# Go >= 1.24
+# Node.js >= 20
+# Git, Make, SQLite3
+# gh CLI（GitHub CLI）
+
+# macOS
+brew install go node git sqlite3 make gh
+
+# Ubuntu/Debian
+sudo apt install golang-go nodejs npm git sqlite3 make
+# gh: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+
+# 确保 ~/go/bin 在 PATH 中
+echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+# 验证
+go version     # >= 1.24
+node --version # >= 20
+gh --version
+```
+
+### 2.2 gh CLI 配置
+
+```bash
+# 登录 GitHub
+gh auth login
+
+# 常用命令
+gh repo list HackForger                          # Org 仓库
+gh issue list -R HackForger/hackforger            # Issue 列表
+gh issue create -R HackForger/hackforger --title "Bug" --body "..."
+gh pr list -R HackForger/hackforger               # PR 列表
+gh pr create --title "feat: bounty" --body "..."  # 在当前 repo 目录下
+gh pr merge 5                                     # merge PR
+gh release create v0.1.0 --title "MVP"
+```
+
+### 2.3 首次构建
+
+```bash
+cd hackforger
+
+# 安装依赖
+make deps
+
+# 编译
+make build          # 完整（backend + frontend）
+make backend        # 只编译后端（~10 秒）
+make frontend       # 只编译前端（~30 秒）
+
+# 启动
+./gitea web
+# 访问 http://localhost:3000 → 安装向导 → 选 SQLite → 创建 admin
+```
+
+---
+
+## 三、Claude Code 配置
+
+### 3.1 CLAUDE.md（项目级指令）
+
+在项目根目录创建 `CLAUDE.md`：
+
+```markdown
+# HackForger 开发指南
+
+## 项目概述
+HackForger 是 Forgejo 的 Fork，新增了 Hackathon、Bounty、Grant、Credits 模块。
+所有新代码集中在 `*/hackforger/` 独立目录，对 Forgejo 原文件改动最少。
+
+## 架构规则
+- Forgejo 是严格分层架构：routers → services → models → modules
+- 上层只能调用下层，不能反向依赖
+- 新功能的 Go 包路径统一在 `forgejo.org/models/hackforger/`、`forgejo.org/services/hackforger/` 等
+- 数据库用 XORM ORM，定义 Go struct + tag 即可自动建表
+- 前端是 Go template 服务端渲染 + 局部 Vue 3 组件增强，不是 SPA
+
+## 目录结构
+- `models/hackforger/` — 数据模型（15 张表）
+- `services/hackforger/` — 业务逻辑
+- `routers/api/v1/hackforger/` — REST API
+- `routers/web/hackforger/` — Web 页面路由
+- `templates/hackforger/` — Go HTML 模板
+- `modules/hackforger/feed/` — Feed 事件类型定义
+- `web_src/js/features/hackforger/` — Vue 组件
+
+## 命名规范
+- Go 文件: snake_case（hackathon.go, bounty_reward.go）
+- Go 结构体: CamelCase（HackathonSubmission, BountyReward）
+- API 路径: kebab-case（/api/v1/hackforger/grant-rounds）
+- 模板文件: snake_case（judge_panel.tmpl）
+- Vue 组件: PascalCase（BountyPanel.vue）
+
+## 常用命令
+- `make backend` — 编译后端
+- `make frontend` — 编译前端
+- `go test ./models/hackforger/... -v` — 跑 model 测试
+- `go test ./services/hackforger/... -v` — 跑 service 测试
+- `./gitea web` — 启动服务器（http://localhost:3000）
+
+## 重要约束
+- 使用 `gh` CLI 操作 GitHub（不要用 `tea`，那是 Codeberg/Forgejo 的 CLI）
+- 不要修改 Forgejo 原有文件，除非在 implementation-plan-draft.md 第 1.2 节列出的 11 个注入点
+- 所有状态变更必须调用 PublishHackforgerAction 写 Feed 事件
+- Credits 的 Deposit/Redeem 必须在 db.WithTx 事务中
+- 内网 HackForger 实例地址: https://hackforger.inside.h2os.cloud
+- API 基础路径: https://hackforger.inside.h2os.cloud/api/v1/hackforger/
+```
+
+### 3.2 Subagent：代码地图扫描
+
+```markdown
+<!-- .claude/agents/codebase-navigator.md -->
+---
+name: codebase-navigator
+description: Scans the HackForger/Forgejo codebase and produces a focused code map for the current task. Use this before starting any feature implementation to understand relevant modules and avoid context overload.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+# Codebase Navigator
+
+You are a code architecture analyst for HackForger (a Forgejo fork). Your job is to scan the codebase and produce a **focused code map** — only the files and functions relevant to the current task.
+
+## Process
+
+1. Understand the task description
+2. Identify which HackForger modules are involved (hackathon/bounty/grants/credits/feed/reputation)
+3. Scan the relevant directories:
+   - `models/hackforger/` for data models
+   - `services/hackforger/` for business logic
+   - `routers/api/v1/hackforger/` for API endpoints
+   - `routers/web/hackforger/` for web routes
+   - `templates/hackforger/` for UI templates
+   - `web_src/js/features/hackforger/` for Vue components
+4. If the task touches Forgejo native features, also scan:
+   - `models/repo/`, `models/issues/`, `models/org/` — for understanding existing models
+   - `services/repository/`, `services/issue/` — for reuse patterns
+   - `routers/web/repo/`, `routers/api/v1/repo/` — for routing patterns
+5. Produce a code map in this format:
+
+\```
+## Code Map: [Task Name]
+
+### Directly Relevant Files
+- `models/hackforger/bounty.go` — Bounty struct, BountyStatus enum
+  - CreateBounty(), GetBountyByIssueID(), UpdateBounty()
+- `services/hackforger/bounty.go` — Business logic
+  - OnPullRequestMerged() — PR merge hook, triggers status change
+  - OnBountyCompleted() — Credits distribution
+
+### Forgejo Files to Reference (read-only)
+- `models/issues/issue.go` — Issue struct (Bounty 1:1 binds to Issue)
+- `services/pull/merge.go` — PR merge flow, need to add hook here
+
+### Files to Create/Modify
+- `services/hackforger/bounty.go` — Add new function: ...
+- `templates/hackforger/bounty/issue_panel.tmpl` — Create new template
+
+### Not Relevant (skip these)
+- `models/hackforger/hackathon.go` — Not needed for this task
+- `services/hackforger/grants.go` — Not needed
+\```
+
+## Rules
+- NEVER include the entire Forgejo codebase. Only map what's needed.
+- For large files, list only the relevant functions, not the entire file.
+- Always check if a Forgejo native function already does what we need before suggesting new code.
+- Flag any Forgejo files in the "11 injection points" list that this task might need to modify.
+```
+
+### 3.3 Subagent：Go/Forgejo 开发专家
+
+```markdown
+<!-- .claude/agents/forgejo-dev.md -->
+---
+name: forgejo-dev
+description: Expert in Forgejo's Go codebase patterns. Use for implementing HackForger features following Forgejo's architectural conventions.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: opus
+---
+
+# Forgejo Development Expert
+
+You are an expert Go developer specializing in Forgejo's architecture. When implementing HackForger features:
+
+## Architecture Rules
+1. **Layer discipline**: routers → services → models → modules. Never import upward.
+2. **XORM patterns**: Use `xorm:"pk autoincr"` tags. Register tables in `models/hackforger/init.go`.
+3. **Error handling**: Return typed errors (e.g., `ErrBountyNotFound`), not generic errors.
+4. **Context propagation**: Always pass `context.Context` as first parameter.
+5. **Database transactions**: Use `db.WithTx(ctx, func(ctx context.Context) error { ... })` for multi-table operations.
+6. **Feed events**: Every state change must call `PublishHackforgerAction()`.
+7. **API style**: Follow Forgejo's existing patterns in `routers/api/v1/repo/`. JSON tags on all struct fields. Swagger comments on all handlers.
+8. **Template style**: Use Go template syntax `{{.Field}}`, `{{range .Items}}`, `{{if .Condition}}`. CSS uses Tailwind classes.
+
+## Common Patterns Reference
+- Creating a new model: See `models/issues/issue.go` for struct + CRUD pattern
+- Creating a new API endpoint: See `routers/api/v1/repo/issue.go` for handler pattern
+- Creating a new web route: See `routers/web/repo/issue.go` for page handler pattern
+- Service with notifications: See `services/issue/issue.go` for notification pattern
+- Cron task: See `services/cron/tasks.go` for registration pattern
+
+## Don'ts
+- Don't use `tea` CLI. Use `gh` for GitHub operations.
+- Don't create Forgejo Actions (`.forgejo/workflows/`) for the GitHub repo. Use GitHub Actions (`.github/workflows/`).
+- Don't use React or any framework other than Vue 3 for frontend components.
+- Don't add external Go dependencies without justification. Forgejo is conservative on deps.
+```
+
+### 3.4 Hooks（防止幻觉和常见错误）
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "intercept",
+            "pattern": "\\btea\\s+(issue|pr|repo|release|login)",
+            "message": "⚠️ 请使用 `gh` 而不是 `tea`。tea 是 Forgejo/Codeberg CLI，我们在 GitHub 上开发。等效命令：gh issue / gh pr / gh repo。API 调用请使用 curl + GITHUB_TOKEN 或 FORGEJO_TOKEN。"
+          },
+          {
+            "type": "intercept",
+            "pattern": "codeberg\\.org/(Synnovator|HackForge)",
+            "message": "⚠️ 项目托管在 GitHub，不是 Codeberg。正确地址：github.com/HackForger/hackforger"
+          },
+          {
+            "type": "intercept",
+            "pattern": "hackforge\\.inside\\.h2os\\.cloud",
+            "message": "⚠️ 内网实例地址已变更为 hackforger.inside.h2os.cloud（多了一个 r）。请更新 URL。"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "intercept",
+            "pattern": "models/(repo|issues|org|user|actions|auth)/",
+            "message": "⚠️ 你正在修改 Forgejo 原有的 model 文件。HackForger 的新代码应该放在 models/hackforger/ 目录下。如果确实需要修改原有文件，请确认是 implementation-plan 中列出的 11 个注入点之一。"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3.5 自定义命令
+
+```markdown
+<!-- .claude/commands/build.md -->
+---
+description: Build HackForger (backend, frontend, or both)
+allowed-tools: Bash
+---
+Build the project. Arguments: "backend", "frontend", "all" (default: all)
+
+If "$ARGUMENTS" is "backend": run `make backend`
+If "$ARGUMENTS" is "frontend": run `make frontend`
+Otherwise: run `make build`
+
+Report any compilation errors clearly.
+```
+
+```markdown
+<!-- .claude/commands/test.md -->
+---
+description: Run HackForger tests
+allowed-tools: Bash, Read, Grep
+---
+Run tests. Arguments: module name or "all"
+
+If "$ARGUMENTS" is "all":
+  Run `go test ./models/hackforger/... ./services/hackforger/... -v -count=1`
+
+If "$ARGUMENTS" is a module name (bounty, hackathon, grants, credits, reputation, feed):
+  Run `go test ./models/hackforger/... ./services/hackforger/... -v -run "Test.*${ARGUMENTS}" -count=1`
+
+If "$ARGUMENTS" is "e2e":
+  Run `go test ./tests/integration/... -v -tags='sqlite sqlite_unlock_notify' -run TestE2E`
+
+Report results with pass/fail summary.
+```
+
+```markdown
+<!-- .claude/commands/codemap.md -->
+---
+description: Generate a focused code map for a task
+allowed-tools: Read, Grep, Glob
+---
+Use the codebase-navigator agent to scan the codebase and produce a focused code map for: $ARGUMENTS
+
+Output the map showing only relevant files, functions, and Forgejo injection points needed.
+```
+
+```markdown
+<!-- .claude/commands/api-test.md -->
+---
+description: Test a HackForger API endpoint against the internal instance
+allowed-tools: Bash
+---
+Test an API endpoint on the internal HackForger instance.
+
+Usage: /api-test METHOD /path [JSON body]
+Example: /api-test GET /hackforger/hackathons
+Example: /api-test POST /hackforger/hackathons '{"name":"test"}'
+
+Execute:
+\```bash
+curl -s -X $METHOD \
+  -H "Authorization: token $FORGEJO_TOKEN" \
+  -H "Content-Type: application/json" \
+  ${BODY:+-d "$BODY"} \
+  "https://hackforger.inside.h2os.cloud/api/v1$PATH" | jq .
+\```
+
+If FORGEJO_TOKEN is not set, warn the user to set it first.
+```
+
+### 3.6 MCP 服务器配置
+
+```json
+// .mcp.json（项目级）
+{
+  "mcpServers": {
+    "forgejo": {
+      "command": "forgejo-mcp",
+      "args": [
+        "--transport", "stdio",
+        "--url", "https://hackforger.inside.h2os.cloud"
+      ],
+      "env": {
+        "FORGEJO_ACCESS_TOKEN": "${FORGEJO_TOKEN}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/context7-mcp"]
+    }
+  }
+}
+```
+
+安装 Forgejo MCP Server：
+
+```bash
+go install codeberg.org/goern/forgejo-mcp/v2@latest
+```
+
+### 3.7 环境变量
+
+```bash
+# ~/.bashrc 或 ~/.zshrc 追加
+
+# GitHub
+export GITHUB_TOKEN="your-github-token"
+
+# HackForger 内网实例
+export FORGEJO_URL="https://hackforger.inside.h2os.cloud"
+export FORGEJO_TOKEN="your-hackforger-instance-token"
+
+# Claude Code 开发
+export HACKFORGER_DEV=true
+```
+
+---
+
+## 四、GitHub Actions / Forgejo Actions Runner
+
+### 4.1 CI 策略
+
+HackForger 使用双 CI 体系：
+- **GitHub Actions** (`.github/workflows/`) — 主仓库 CI，跑测试、lint、构建
+- **Forgejo Actions** (`.forgejo/workflows/`) — 自部署的 HackForger 实例使用
+
+开发阶段的核心逻辑在 Service 层，不依赖 CI。开发和单元测试在本地完成。
+
+### 4.2 自部署实例：Forgejo Actions Runner
+
+在内网服务器上部署 Runner（用于自部署的 HackForger 实例）：
+
+```yaml
+# docker-compose.runner.yml（部署在内网服务器上）
+services:
+  runner-dind:
+    image: docker:dind
+    container_name: hackforger-dind
+    privileged: true
+    command: ['dockerd', '-H', 'tcp://0.0.0.0:2375', '--tls=false']
+    restart: unless-stopped
+
+  runner:
+    image: data.forgejo.org/forgejo/runner:6.2
+    container_name: hackforger-runner
+    depends_on: [runner-dind]
+    environment:
+      DOCKER_HOST: tcp://hackforger-dind:2375
+    volumes:
+      - ./runner-data:/data
+    restart: unless-stopped
+```
+
+```bash
+# 注册 Runner
+docker exec -it hackforger-runner forgejo-runner register \
+  --instance https://hackforger.inside.h2os.cloud \
+  --token RUNNER_TOKEN \
+  --name hackforger-runner \
+  --labels docker:docker://node:20-bookworm
+
+docker exec -it hackforger-runner forgejo-runner daemon
+```
+
+### 4.3 上游仓库的 Actions/Bot
+
+Forgejo 上游仓库的 `.forgejo/workflows/` 是给 Forgejo 自身 CI 用的。我们的策略：
+
+| 上游配置 | 处理 |
+|---------|------|
+| `.forgejo/workflows/testing.yml` | **保留**，供自部署 HackForger 实例使用 |
+| `.forgejo/workflows/release.yml` | **保留但暂不用**，我们暂时不需要自动 release |
+| `.github/workflows/` | **新增**，GitHub 主仓库的 CI/CD |
+| Renovate/Dependabot 配置 | **关闭**，依赖更新跟随上游 |
+| Issue/PR 模板 | **替换为我们自己的模板** |
+
+---
+
+## 五、内网 HackForger 实例
+
+### 5.1 app.ini 配置
+
+```ini
+; 部署在内网服务器上
+
+[server]
+DOMAIN = hackforger.inside.h2os.cloud
+ROOT_URL = https://hackforger.inside.h2os.cloud/
+HTTP_ADDR = 0.0.0.0
+HTTP_PORT = 3000
+SSH_DOMAIN = hackforger.inside.h2os.cloud
+SSH_PORT = 22
+DISABLE_SSH = false
+LFS_START_SERVER = true
+
+[database]
+DB_TYPE = sqlite3
+PATH = /data/hackforger/hackforger.db
+
+[actions]
+ENABLED = true
+DEFAULT_ACTIONS_URL = https://data.forgejo.org
+
+[hackforger]
+ENABLED = true
+
+[hackforger.hackathon]
+MAX_TRACKS_PER_HACKATHON = 10
+AUTO_CREATE_TEAM_ON_APPROVE = true
+
+[hackforger.bounty]
+ALLOWED_CURRENCIES = USD,CNY,EUR,credits
+AUTO_EXPIRE_CHECK_INTERVAL = 5m
+
+[hackforger.credits]
+ENABLED = true
+INITIAL_BALANCE = 0
+
+[hackforger.reputation]
+RECALC_INTERVAL = 1h
+SCORE_WEIGHTS = stars:1,bounties:5,hackathon_wins:10,grants:3
+
+[hackforger.feed]
+GLOBAL_EVENTS_IN_FEED = true
+
+[hackforger.assistant]
+ENABLED = false
+; 后续启用时配置：
+; LLM_PROVIDER = ollama
+; LLM_API_URL = http://localhost:11434/v1
+; LLM_MODEL = llama3.2
+```
+
+### 5.2 HTTPS 配置
+
+内网通过反向代理提供 HTTPS（假设已有 Caddy/Nginx）：
+
+```
+# Caddyfile
+hackforger.inside.h2os.cloud {
+    reverse_proxy localhost:3000
+    tls internal  # 或使用内网 CA 签发的证书
+}
+```
+
+---
+
+## 六、开发工作流
+
+### 6.1 日常流程（Claude Code）
+
+```bash
+# 1. 进入项目目录
+cd hackforger
+
+# 2. 启动 Claude Code
+claude
+
+# 3. 开始任务前先扫描代码地图
+> /codemap bounty status machine implementation
+
+# 4. 开发功能
+> 实现 Bounty 的 exclusive 模式状态机，包括 Open → Claimed → InReview → Completed → Paid 的转换逻辑
+
+# 5. 编译检查
+> /build backend
+
+# 6. 运行测试
+> /test bounty
+
+# 7. 测试 API
+> /api-test GET /hackforger/bounties
+
+# 8. 提交
+> 提交当前改动，commit message: "feat(bounty): implement exclusive mode status machine"
+```
+
+### 6.2 团队协作
+
+```bash
+# 创建功能分支
+git checkout -b feat/bounty develop
+git push -u origin feat/bounty
+
+# 开发完成后创建 PR（使用 gh）
+gh pr create \
+  --title "feat(bounty): implement exclusive mode" \
+  --body "Implements the Bounty exclusive mode status machine..." \
+  --base develop
+
+# Review + Merge
+gh pr merge <PR_NUMBER>
+```
+
+### 6.3 测试
+
+```bash
+# 单元测试
+go test ./models/hackforger/... ./services/hackforger/... -v -count=1
+
+# 只跑某个测试
+go test ./services/hackforger/... -v -run TestExclusiveBountyFlow_Happy
+
+# 集成测试（需要内网实例运行）
+go test ./tests/integration/... -v -tags='sqlite sqlite_unlock_notify' -run TestE2E_Phase1
+
+# 覆盖率
+go test ./models/hackforger/... ./services/hackforger/... -coverprofile=coverage.out
+go tool cover -html=coverage.out
+```
+
+---
+
+## 七、首次启动检查清单
+
+```
+□ GitHub 账号已加入 HackForger org，有 repo write 权限
+□ gh auth login 配置完成
+□ git clone 成功，remote 配置正确（origin=GitHub, upstream=Forgejo/Codeberg）
+□ Go >= 1.24 / Node >= 20 / SQLite3 已安装
+□ make deps 成功
+□ make build 编译成功
+□ ./gitea web 启动成功
+□ 安装向导完成（SQLite, admin 账号）
+□ CLAUDE.md 已放置在项目根目录
+□ .claude/agents/ 目录包含 codebase-navigator.md 和 forgejo-dev.md
+□ .claude/settings.json 包含 hooks 配置（拦截 tea/codeberg 调用）
+□ .claude/commands/ 包含 build/test/codemap/api-test 命令
+□ 环境变量 GITHUB_TOKEN / FORGEJO_TOKEN 已设置
+□ GET https://hackforger.inside.h2os.cloud/api/v1/hackforger/hackathons → 200
+```


### PR DESCRIPTION
## Summary
- Set up complete Claude Code development environment for HackForger (migrated from Codeberg to GitHub)
- Created CLAUDE.md, subagents, slash commands, hooks, MCP config, and tmux launcher
- Updated docs/dev-setup.md to reflect GitHub platform, gh CLI, unified hackforger naming

## Files
| File | Purpose |
|------|---------|
| CLAUDE.md | Project-level instructions (architecture, naming, constraints) |
| .claude/agents/*.md | codebase-navigator + forgejo-dev subagents |
| .claude/commands/*.md | /build, /test, /codemap, /api-test commands |
| .claude/settings.json | Hooks: intercept tea/codeberg/old-URL usage |
| .mcp.json | forgejo-mcp (self-hosted instance) + context7 |
| claude.sh | tmux-based launcher with session management |
| docs/dev-setup.md | Full dev setup guide (updated for GitHub migration) |
| .gitignore | Agent-setup runtime entries appended |

## Platform migration changes applied
- Repo: git@github.com:HackForger/hackforger.git
- CLI: gh (was tea)
- CI: GitHub Actions primary, Forgejo Actions kept for self-hosted
- Naming: all hackforge -> hackforger (code paths, API paths, config sections)
- Instance: hackforger.inside.h2os.cloud
- Env: GITHUB_TOKEN + FORGEJO_TOKEN dual

## Test plan
- [ ] Verify claude.sh launches correctly in tmux
- [ ] Verify hooks fire on tea / codeberg.org usage
- [ ] Verify /build backend compiles successfully
- [ ] Verify CLAUDE.md is picked up by new Claude Code sessions

Generated with [Claude Code](https://claude.com/claude-code)