### PR TITLE
fix(ui): truncate descriptions on explore pages (#43)

### DIFF
--- a/modules/templates/util_string.go
+++ b/modules/templates/util_string.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"forgejo.org/modules/base"
+	"forgejo.org/modules/markup/mdstripper"
 	"forgejo.org/modules/util"
 )
 
@@ -78,4 +79,13 @@ func (su *StringUtils) RemoveAll(s string, all ...string) string {
 
 func (su *StringUtils) RemoveAllPrefix(s string, all ...string) string {
 	return util.RemoveAllStr(s, true, all...)
+}
+
+func (su *StringUtils) PlainTextPreview(s string, max int) string {
+	if s == "" {
+		return ""
+	}
+	plain, _ := mdstripper.StripMarkdown([]byte(s))
+	result := strings.Join(strings.Fields(string(plain)), " ")
+	return base.EllipsisString(result, max)
 }

--- a/templates/hackforger/grants/explore.tmpl
+++ b/templates/hackforger/grants/explore.tmpl
@@ -11,7 +11,7 @@
 				<div class="hf-row-left">
 					<div>
 						<a class="tw-text-lg tw-font-medium" href="{{AppSubUrl}}/grants/{{.Slug}}">{{.Name}}</a>
-						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1 markup">{{.Description}}</div>{{end}}
+						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1">{{StringUtils.PlainTextPreview .Description 200}}</div>{{end}}
 						<div class="tw-mt-1 tw-flex tw-items-center tw-gap-2">
 							<span class="hf-badge {{if eq .Status 0}}hf-badge-neutral{{else if eq .Status 1}}hf-badge-green{{else if eq .Status 2}}hf-badge-blue{{else if eq .Status 3}}hf-badge-yellow{{else if eq .Status 4}}hf-badge-purple{{else}}hf-badge-red{{end}}">
 								{{if eq .Status 0}}{{ctx.Locale.Tr "hackforger.grant.round.status.draft"}}

--- a/templates/hackforger/hackathon/explore.tmpl
+++ b/templates/hackforger/hackathon/explore.tmpl
@@ -12,7 +12,7 @@
 				<div class="hf-row-left">
 					<div>
 						<a class="tw-text-lg tw-font-semibold" href="{{AppSubUrl}}/hackathon/{{.Slug}}">{{.Name}}</a>
-						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1 markup">{{.Description}}</div>{{end}}
+						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1">{{StringUtils.PlainTextPreview .Description 200}}</div>{{end}}
 					</div>
 				</div>
 				<span class="hf-badge {{if eq .StatusCache 0}}hf-badge-neutral{{else if eq .StatusCache 1}}hf-badge-green{{else if eq .StatusCache 2}}hf-badge-blue{{else if eq .StatusCache 3}}hf-badge-yellow{{else if eq .StatusCache 4}}hf-badge-neutral{{else}}hf-badge-red{{end}}">

--- a/templates/hackforger/submission/explore.tmpl
+++ b/templates/hackforger/submission/explore.tmpl
@@ -46,7 +46,7 @@
 								</a>
 							{{end}}
 						</div>
-						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1 markup">{{.Description}}</div>{{end}}
+						{{if .Description}}<div class="tw-text-sm tw-text-gray tw-mb-1">{{StringUtils.PlainTextPreview .Description 200}}</div>{{end}}
 						<div class="tw-text-sm tw-text-gray tw-flex tw-items-center tw-gap-3 tw-flex-wrap">
 							<span class="tw-flex tw-items-center tw-gap-1">
 								{{if .AuthorAvatar}}<img class="tw-rounded-full" src="{{.AuthorAvatar}}" width="16" height="16" alt="">{{end}}


### PR DESCRIPTION
## Summary

- Add `StringUtils.PlainTextPreview` template helper that strips Markdown and truncates to 200 chars
- Applied to hackathon, grants, and submission explore pages
- Descriptions now show plain text preview instead of raw Markdown

### Before / After
- Before: full Markdown description rendered on explore cards, making pages very long
- After: clean 200-char plain text preview with "..." truncation

Closes #43

## Test plan
- [x] Hackathon explore page shows truncated plain text descriptions
- [x] Grants explore page shows truncated plain text descriptions
- [ ] Submission explore page shows truncated descriptions
- [ ] Verify no layout breakage on explore pages
- [ ] Switch to English locale and verify truncation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)