### PR TITLE
fix: bounty issue comment logging + grant notification user (#34 #35)

### DIFF
--- a/services/hackforger/bounty.go
+++ b/services/hackforger/bounty.go
@@ -20,19 +20,26 @@ import (
 
 // postBountyIssueComment adds a timeline comment to the bounty's linked Issue
 // when a bounty event occurs (created, applied, accepted, completed, etc.).
+// Errors are logged but not propagated — issue comments are best-effort and
+// should not block bounty operations.
 func postBountyIssueComment(ctx context.Context, bounty *hackforger_model.Bounty, doerID int64, message string) {
 	doer, err := user_model.GetUserByID(ctx, doerID)
 	if err != nil {
+		log.Error("postBountyIssueComment: GetUserByID(%d): %v", doerID, err)
 		return
 	}
 	issue, err := issues_model.GetIssueByID(ctx, bounty.IssueID)
 	if err != nil {
+		log.Error("postBountyIssueComment: GetIssueByID(%d): %v", bounty.IssueID, err)
 		return
 	}
 	if err := issue.LoadRepo(ctx); err != nil {
+		log.Error("postBountyIssueComment: LoadRepo for issue %d: %v", bounty.IssueID, err)
 		return
 	}
-	_, _ = issue_service.CreateIssueComment(ctx, doer, issue.Repo, issue, message, nil)
+	if _, err := issue_service.CreateIssueComment(ctx, doer, issue.Repo, issue, message, nil); err != nil {
+		log.Error("postBountyIssueComment: CreateIssueComment for issue %d: %v", bounty.IssueID, err)
+	}
 }
 
 // closeBountyIssue closes the Issue linked to a bounty when it completes.

--- a/services/hackforger/grants.go
+++ b/services/hackforger/grants.go
@@ -460,10 +460,12 @@ func ApproveProject(ctx context.Context, doerID, projectID int64) error {
 		return err
 	}
 
-	// Notify the applicant about approval (HF-018)
-	doer, _ := user_model.GetUserByID(ctx, doerID)
-	if doer != nil {
-		notify_service.HackforgerEntityStatusChanged(ctx, doer, &notify_service.HackforgerEventOpts{
+	// Notify about approval (HF-018)
+	// Use the applicant as the actor so the feed reads "[applicant] received a grant"
+	// rather than "[admin] received a grant".
+	applicant, _ := user_model.GetUserByID(ctx, project.UserID)
+	if applicant != nil {
+		notify_service.HackforgerEntityStatusChanged(ctx, applicant, &notify_service.HackforgerEventOpts{
 			OpType:       hackforger_model.ActionGrantAwarded,
 			EntityType:   "grant_project",
 			EntityID:     project.ID,


### PR DESCRIPTION
## Summary

**#34 — Bounty accept error**: `postBountyIssueComment` silently swallowed all errors (void return). Now logs errors via `log.Error()` at each failure point (user lookup, issue lookup, repo load, comment creation). Errors are logged but not propagated — issue comments are best-effort.

**#35 — Grant notification wrong user**: `ApproveProject` passed the admin (`doer`) to the feed notification instead of the applicant. Feed showed "hackforger received a grant" when it should show "[applicant] received a grant". Fixed by using `project.UserID` as the notification actor.

Ref #34, ref #35

## Test plan
- [ ] Accept a bounty application → check server logs for any postBountyIssueComment errors
- [ ] Approve a grant project → verify feed shows applicant name, not admin name

🤖 Generated with [Claude Code](https://claude.com/claude-code)