### PR TITLE
fix: allow submission update after repo-based registration (#29)

### DIFF
--- a/models/hackforger/hackathon_submission.go
+++ b/models/hackforger/hackathon_submission.go
@@ -150,6 +150,19 @@ func SubmissionExistsByUserAndTrack(ctx context.Context, userID, trackID int64) 
 	return db.GetEngine(ctx).Where("user_id = ? AND track_id = ?", userID, trackID).Exist(&HackathonSubmission{})
 }
 
+// GetSubmissionByUserAndHackathon returns the submission for a given user in a hackathon (if any).
+func GetSubmissionByUserAndHackathon(ctx context.Context, hackathonID, userID int64) (*HackathonSubmission, error) {
+	s := &HackathonSubmission{}
+	has, err := db.GetEngine(ctx).Where("hackathon_id = ? AND user_id = ?", hackathonID, userID).Get(s)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, nil
+	}
+	return s, nil
+}
+
 // CountSubmissions returns the number of submissions for a given hackathon.
 func CountSubmissions(ctx context.Context, hackathonID int64) (int64, error) {
 	return db.GetEngine(ctx).Where("hackathon_id = ?", hackathonID).Count(new(HackathonSubmission))

--- a/routers/web/hackforger/hackathon.go
+++ b/routers/web/hackforger/hackathon.go
@@ -464,8 +464,11 @@ func SubmitForm(ctx *context.Context) {
 	if h == nil {
 		return
 	}
+	// Allow submit/update during Registration (to update after repo-based registration)
+	// and Development phases
 	canSubmit, _ := hackforger_service.AllowsAction(ctx, "hackathon", h.ID, "submit_work")
-	if !canSubmit {
+	canRegister, _ := hackforger_service.AllowsAction(ctx, "hackathon", h.ID, "register")
+	if !canSubmit && !canRegister {
 		ctx.Flash.Error(ctx.Tr("hackforger.hackathon.error.invalid_phase"))
 		ctx.Redirect("/hackathon/" + h.Slug)
 		return
@@ -497,6 +500,12 @@ func SubmitForm(ctx *context.Context) {
 		ctx.Data["LockedRepoID"] = reg.RepoID
 	}
 
+	// Prefill form with existing submission data (if any)
+	existing, _ := hackforger_model.GetSubmissionByUserAndHackathon(ctx, h.ID, ctx.Doer.ID)
+	if existing != nil {
+		ctx.Data["ExistingSubmission"] = existing
+	}
+
 	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
 	ctx.Data["UploadUrl"] = setting.AppSubURL + "/hackforger/attachments"
 	ctx.Data["UploadRemoveUrl"] = ""
@@ -514,7 +523,8 @@ func SubmitPost(ctx *context.Context) {
 		return
 	}
 	canSubmit, _ := hackforger_service.AllowsAction(ctx, "hackathon", h.ID, "submit_work")
-	if !canSubmit {
+	canRegister, _ := hackforger_service.AllowsAction(ctx, "hackathon", h.ID, "register")
+	if !canSubmit && !canRegister {
 		ctx.Flash.Error(ctx.Tr("hackforger.hackathon.error.invalid_phase"))
 		ctx.Redirect("/hackathon/" + h.Slug)
 		return
@@ -527,6 +537,32 @@ func SubmitPost(ctx *context.Context) {
 	}
 	trackID, _ := strconv.ParseInt(ctx.FormString("track_id"), 10, 64)
 	repoID, _ := strconv.ParseInt(ctx.FormString("repo_id"), 10, 64)
+
+	// Upsert: if user already has a submission (created at registration), update it;
+	// otherwise create a new one.
+	existing, _ := hackforger_model.GetSubmissionByUserAndHackathon(ctx, h.ID, ctx.Doer.ID)
+	if existing != nil {
+		existing.Title = ctx.FormString("title")
+		existing.Description = ctx.FormString("description")
+		existing.DemoURL = ctx.FormString("demo_url")
+		if trackID > 0 {
+			existing.TrackID = trackID
+		}
+		if repoID > 0 {
+			existing.RepoID = repoID
+		}
+		if err := hackforger_model.UpdateSubmission(ctx, existing); err != nil {
+			log.Error("UpdateSubmission: %v", err)
+			ctx.Flash.Error(ctx.Tr("hackforger.hackathon.error.internal"))
+			ctx.Redirect("/hackathon/" + h.Slug + "/submit")
+			return
+		}
+		ctx.Flash.Success(ctx.Tr("hackforger.hackathon.submit.success"))
+		ctx.Redirect("/hackathon/" + h.Slug)
+		return
+	}
+
+	// No existing submission — create new
 	s := &hackforger_model.HackathonSubmission{
 		HackathonID:    h.ID,
 		RegistrationID: reg.ID,

--- a/templates/hackforger/hackathon/submit.tmpl
+++ b/templates/hackforger/hackathon/submit.tmpl
@@ -6,14 +6,14 @@
 		<div class="hf-card">
 			<div class="hf-card-body">
 				<form class="ui form" method="post">
-					<div class="required field"><label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.title"}}</label><input name="title" required></div>
+					<div class="required field"><label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.title"}}</label><input name="title" required value="{{if .ExistingSubmission}}{{.ExistingSubmission.Title}}{{end}}"></div>
 					<div class="field">
 						<label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.description"}}</label>
 						{{template "shared/combomarkdowneditor" (dict
 							"MarkdownPreviewUrl" (print AppSubUrl "/hackforger/markup")
 							"MarkdownPreviewContext" ""
 							"TextareaName" "description"
-							"TextareaContent" ""
+							"TextareaContent" (Iif .ExistingSubmission .ExistingSubmission.Description "")
 							"TextareaPlaceholder" (ctx.Locale.TrString "hackforger.hackathon.submit.field.description")
 							"DropzoneParentContainer" "form"
 						)}}
@@ -21,19 +21,30 @@
 						<div class="field">{{template "repo/upload" .}}</div>
 						{{end}}
 					</div>
-					<div class="field"><label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.demo_url"}}</label><input name="demo_url" type="url"></div>
+					<div class="field"><label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.demo_url"}}</label><input name="demo_url" type="url" value="{{if .ExistingSubmission}}{{.ExistingSubmission.DemoURL}}{{end}}"></div>
 					{{if .UserRepos}}
 					<div class="field">
 						<label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.repo"}}</label>
 						<select name="repo_id" class="ui search selection dropdown">
 							<option value="0">— {{ctx.Locale.Tr "hackforger.hackathon.submit.field.repo_none"}} —</option>
+							{{$lockedRepo := .LockedRepoID}}
+							{{$existingRepo := 0}}{{if .ExistingSubmission}}{{$existingRepo = .ExistingSubmission.RepoID}}{{end}}
 							{{range .UserRepos}}
-							<option value="{{.ID}}">{{.FullName}}</option>
+							<option value="{{.ID}}" {{if or (eq .ID $lockedRepo) (eq .ID $existingRepo)}}selected{{end}}>{{.FullName}}</option>
 							{{end}}
 						</select>
 					</div>
 					{{end}}
-					{{if .Tracks}}<div class="field hf-track-select"><label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.track"}}</label><select name="track_id" class="ui selection dropdown"><option value="0">— None —</option>{{range .Tracks}}<option value="{{.ID}}" title="{{.Name}}">{{.Name}}</option>{{end}}</select></div>{{end}}
+					{{if .Tracks}}
+					<div class="field hf-track-select">
+						<label>{{ctx.Locale.Tr "hackforger.hackathon.submit.field.track"}}</label>
+						<select name="track_id" class="ui selection dropdown">
+							<option value="0">— None —</option>
+							{{$existingTrack := 0}}{{if .ExistingSubmission}}{{$existingTrack = .ExistingSubmission.TrackID}}{{end}}
+							{{range .Tracks}}<option value="{{.ID}}" title="{{.Name}}" {{if eq .ID $existingTrack}}selected{{end}}>{{.Name}}</option>{{end}}
+						</select>
+					</div>
+					{{end}}
 					<button class="hf-btn hf-btn-primary" type="submit">{{ctx.Locale.Tr "hackforger.hackathon.submit"}}</button>
 				</form>
 			</div>

--- a/templates/hackforger/hackathon/view.tmpl
+++ b/templates/hackforger/hackathon/view.tmpl
@@ -154,8 +154,8 @@
 		</div>
 		{{end}}
 
-		{{/* Submit button */}}
-		{{if and (eq .Hackathon.StatusCache 2) .IsRegistered}}
+		{{/* Submit / Update button — visible during Registration and Hacking phases for registered users */}}
+		{{if and (or (eq .Hackathon.StatusCache 1) (eq .Hackathon.StatusCache 2)) .IsRegistered}}
 		<div class="tw-text-center tw-my-4">
 			<a class="hf-btn hf-btn-primary" href="{{AppSubUrl}}/hackathon/{{.Hackathon.Slug}}/submit">{{svg "octicon-upload" 16}} {{ctx.Locale.Tr "hackforger.hackathon.submit"}}</a>
 		</div>


### PR DESCRIPTION
## Summary

After the registration simplification (PR #66), registration creates both a Registration and Submission record simultaneously. But the submit flow only supported creating **new** submissions, causing:
- "duplicate submission" error during development phase
- Submit button hidden during registration phase (registered users couldn't update)

### Changes
- **SubmitPost**: upsert — update existing submission if present, create new only if none exists
- **SubmitForm/SubmitPost**: allow access during both Registration and Development phases
- **View template**: show submit button for registered users in Registration phase
- **Submit template**: prefill form with existing submission data (title, description, demo URL, repo, track)
- **Model**: add `GetSubmissionByUserAndHackathon` helper

Ref #29

## Test plan
- [ ] Register for hackathon (creates submission) → click submit → form prefilled with registration data
- [ ] Update title/description → submit → verify data saved
- [ ] Development phase: submit button visible, form prefilled, can update
- [ ] Unregistered user cannot access submit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)