### PR TITLE
fix(js): null-guard ComboMarkdownEditor.setupLinkInserter

### DIFF
--- a/web_src/js/features/comp/ComboMarkdownEditor.js
+++ b/web_src/js/features/comp/ComboMarkdownEditor.js
@@ -330,7 +330,13 @@ class ComboMarkdownEditor {
   }
 
   setupLinkInserter() {
+    // The "Insert link" modal is only rendered on pages whose templates
+    // include the new-markdown-link partial (issue/PR comment forms, etc.).
+    // Editors mounted in other contexts (e.g. some HackForger forms) won't
+    // have this modal — skip silently rather than throwing on the null
+    // querySelector result.
     const newLinkModal = this.container.querySelector('div[data-modal-name="new-markdown-link"]');
+    if (!newLinkModal) return;
     newLinkModal.setAttribute('data-markdown-link-modal-id', this.elementIdSuffix);
     const textarea = document.getElementById(`_combo_markdown_editor_${this.elementIdSuffix}`);
 


### PR DESCRIPTION
## Bug

\`/hackforger/oss-project/issues/9\` (and any page mounting ComboMarkdownEditor without the new-markdown-link partial) throws on load:

\`\`\`
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'setAttribute')
    at al.setupLinkInserter (ComboMarkdownEditor.js:334:18)
    at al.init (ComboMarkdownEditor.js:57:10)
\`\`\`

## Cause

\`ComboMarkdownEditor.js:332-334\`:
\`\`\`js
setupLinkInserter() {
  const newLinkModal = this.container.querySelector('div[data-modal-name="new-markdown-link"]');
  newLinkModal.setAttribute(...)  // ← null check missing
\`\`\`

The link-inserter modal is only rendered on issue/PR comment forms. HackForger forms (and any other context that mounts the markdown editor without including the modal partial) trigger the null deref.

## Fix

Bail out silently if the modal isn't present — the rest of the editor (textarea, table inserter, preview) keeps working.

## Test

After merge + frontend rebuild + deploy, the console error should disappear on https://hackforger.inside.h2os.cloud/hackforger/oss-project/issues/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)