### PR TITLE
fix(theme/light): .text.primary + basic primary chip/button readability

### DIFF
--- a/custom/public/assets/css/theme-hackforger-light.css
+++ b/custom/public/assets/css/theme-hackforger-light.css
@@ -155,6 +155,22 @@ select:focus-visible,
     outline-offset: 3px;
 }
 
+/* Bundled utility classes that hardcode --color-primary as TEXT with
+ * !important — bypasses the link cascade fix from PR #88. On light
+ * theme --color-primary is fluorescent #BBFD3B (1.85:1 on cream — fails
+ * AA badly). The most visible offender: .text.primary on /explore/repos
+ * repo names. Override to use the ink-scale dark-2 (6.79:1 AA). */
+.text.primary,
+.ui.label.basic.primary {
+    color: var(--color-primary-dark-2) !important;
+}
+.ui.basic.primary.button {
+    /* Outline button: keep border + text both dark-green for cohesion.
+     * Hover/active still reach for fluorescent via primary-hover/active. */
+    color: var(--color-primary-dark-2);
+    border-color: var(--color-primary-dark-2);
+}
+
 /* Logo theme swap — orange variant on light theme.
  * Attribute selector covers all 4 call-sites (header, home, signin, 500),
  * since 3 of 4 templates emit the img with no class. Both source and


### PR DESCRIPTION
## Summary

Hotfix for residual fluorescent-green-text bug after PR #88.

User report: \`/explore/repos\` repo names still rendering fluorescent green even after the PR #88 link palette fix.

Root cause: bundled utility class \`.text.primary { color: var(--color-primary) !important }\` forces \`--color-primary\` (the action-surface fluorescent #BBFD3B) as text, bypassing the link cascade entirely. On cream paper that's 1.85:1 — fails WCAG AA badly.

Added 3 selectors using the ink-scale \`dark-2\` (#3D5A09, 6.79:1 AA):
- \`.text.primary\` — the reported bug (repo names on /explore/repos)
- \`.ui.label.basic.primary\` — basic primary chips
- \`.ui.basic.primary.button\` — outline primary button (text + border)

Filled \`.ui.primary.button\` keeps fluorescent fill (action surface, intentional).

## Test plan

- [ ] Hard-refresh \`/explore/repos\` — repo names readable forest-green ink (was fluorescent)
- [ ] Find a basic primary chip somewhere (e.g., \`/explore/users\`) — readable text
- [ ] Find an outline primary button (form Cancel-equivalent) — text + border in dark green
- [ ] Filled primary buttons unchanged (still fluorescent)
- [ ] Dark theme: no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)