### PR TITLE
fix(#69): replace '组织:' with '活动ID:' on hackathon view page

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -4249,6 +4249,7 @@ hackathon.error.track_not_found = Track not found.
 hackathon.error.track_update_failed = Failed to update track.
 hackathon.view.organizer = Organizer
 hackathon.view.org = Organization
+hackathon.view.activity_id = Activity ID
 hackathon.view.timeline = Timeline
 hackathon.view.registration_end = Registration Ends
 hackathon.view.hacking_end = Hacking Ends

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -4243,6 +4243,7 @@ hackathon.error.track_not_found = 赛道未找到。
 hackathon.error.track_update_failed = 赛道更新失败。
 hackathon.view.organizer = 组织者
 hackathon.view.org = 组织
+hackathon.view.activity_id = 活动ID
 hackathon.view.timeline = 时间线
 hackathon.view.registration_end = 报名截止
 hackathon.view.hacking_end = 开发截止

--- a/templates/hackforger/hackathon/view.tmpl
+++ b/templates/hackforger/hackathon/view.tmpl
@@ -11,8 +11,8 @@
 					{{if .Owner}}
 					<span class="tw-text-sm tw-text-gray">{{ctx.Locale.Tr "hackforger.hackathon.view.organizer"}}: <a href="{{AppSubUrl}}/{{.Owner.Name}}">{{.Owner.Name}}</a></span>
 					{{end}}
-					{{if .LinkedOrg}}
-					<span class="tw-text-sm tw-text-gray">{{ctx.Locale.Tr "hackforger.hackathon.view.org"}}: <a href="{{AppSubUrl}}/{{.LinkedOrg.Name}}">{{svg "octicon-organization" 14}} {{.LinkedOrg.Name}}</a></span>
+					{{if .Hackathon.Slug}}
+					<span class="tw-text-sm tw-text-gray">{{ctx.Locale.Tr "hackforger.hackathon.view.activity_id"}}: {{svg "octicon-tag" 14}} <code>{{.Hackathon.Slug}}</code></span>
 					{{end}}
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- The hackathon view page (`/hackathon/{slug}`) was rendering **\"组织: 2nd-dishui-opc-w1\"** next to the hackathon name. The slug is the activity's identifier, but labeling it \"Organization\" confused users — they're looking at a hackathon, not the infrastructure org.
- Fix: relabel + rebind the value.

## Changes

| Item | Before | After |
|---|---|---|
| Locale label | `hackathon.view.org` = \"Organization\" / \"组织\" | `hackathon.view.activity_id` = \"Activity ID\" / \"活动ID\" (new key; old key retained in case it's used elsewhere later) |
| Displayed value | `.LinkedOrg.Name` | `.Hackathon.Slug` — the activity's own unique identifier |
| Icon | `octicon-organization` 🏢 | `octicon-tag` 🏷 |
| Markup | `<a href=...>{{name}}</a>` | `<code>{{slug}}</code>` (dropped link; slug is URL-safe-identifier style) |
| Guard | `{{if .LinkedOrg}}` | `{{if .Hackathon.Slug}}` (always populated → shows on draft hackathons too) |

## Files touched

- `templates/hackforger/hackathon/view.tmpl` — 2 lines
- `options/locale/locale_en-US.ini` — +1 line (new key `Activity ID`)
- `options/locale/locale_zh-CN.ini` — +1 line (new key `活动ID`)

## Test plan

- [x] Backend build with `TAGS=\"bindata sqlite sqlite_unlock_notify\" make backend` — bindata embeds template + locale without syntax errors
- [ ] E2E via agent-browser after merge + instance restart: verify `/hackathon/{slug}` shows **\"活动ID: 🏷 {slug}\"** (no longer \"组织: ...\")

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)