### PR TITLE
docs: retrofit spec + plan for light-link-readability (PR #88)

### DIFF
--- a/docs/superpowers/plans/2026-04-21-light-link-readability.md
+++ b/docs/superpowers/plans/2026-04-21-light-link-readability.md
@@ -1,0 +1,337 @@
+# Light Theme Link Readability Hotfix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix WCAG-AA-failing light theme link colors per `2026-04-21-light-link-readability-design.md`.
+
+**Architecture:** Edits localized to the override block at the END of `custom/public/assets/css/theme-hackforger-light.css`. Dark theme untouched.
+
+**Tech Stack:** CSS only.
+
+---
+
+### Task 1: Set up worktree
+
+**Files:**
+- Worktree: `/Users/h2oslabs/.config/superpowers/worktrees/hackforger/light-link-readability`
+- Branch: `fix/light-link-readability`
+
+- [ ] **Step 1: Create worktree from latest origin**
+
+```bash
+git worktree add /Users/h2oslabs/.config/superpowers/worktrees/hackforger/light-link-readability \
+  -b fix/light-link-readability origin/v0.1-dev/hackforger
+```
+
+- [ ] **Step 2: Seed app.ini for local server**
+
+```bash
+cp /Users/h2oslabs/Workspace/hackforger/custom/conf/app.ini \
+   /Users/h2oslabs/.config/superpowers/worktrees/hackforger/light-link-readability/custom/conf/app.ini
+```
+
+- [ ] **Step 3: Verify baseline**
+
+```bash
+cd /Users/h2oslabs/.config/superpowers/worktrees/hackforger/light-link-readability
+git log --oneline -3
+```
+
+Expected HEAD ≥ `5d13c7b` (PR #87 merge).
+
+---
+
+### Task 2: Verify the call-site list (reviewer-mandated grep)
+
+**Goal:** Reviewer noted `--color-primary-dark-1` is consumed as text in some bundled CSS files. Confirm no OTHER text consumers exist that the spec missed.
+
+- [ ] **Step 1: Grep for all consumers of dark-1/2/3/4 in source CSS**
+
+```bash
+cd /Users/h2oslabs/.config/superpowers/worktrees/hackforger/light-link-readability
+grep -rn "var(--color-primary-dark-[0-9])" web_src/css/ templates/ 2>&1 | head -30
+```
+
+- [ ] **Step 2: Sanity-check that all uses are either**
+  - `color: var(...)` — text use, MUST pass AA at 4.5:1 against any surface where it appears
+  - `background-color`, `border-color`, `box-shadow` — non-text, 3:1 minimum
+  - In a `:hover` / `:active` rule on a button-like element
+
+If any text-use consumer maps `dark-1` to a surface that brings the ratio below 4.5:1, escalate before proceeding (open a new spec; don't ship a regression).
+
+The new `dark-1: #4D7008` is 4.92:1 against `#efece1` (body), 4.42:1 against `#e3decd` (header — JUST under AA), 4.67:1 against `#e7e3d4` (nav). On `#ddd8c5` highlight it's 3.92:1 — fails AA. **If a consumer renders dark-1 text on highlight surface, this is a known limitation; document and accept (highlight is transient/hover state).**
+
+No commit yet — verification only.
+
+---
+
+### Task 3: Apply CSS edits to light theme
+
+**Files:**
+- Modify: `custom/public/assets/css/theme-hackforger-light.css`
+
+- [ ] **Step 1: Read current state of the override block**
+
+Use the Read tool on lines 14-55 to confirm the current `:root` block matches what the plan expects.
+
+- [ ] **Step 2: Replace the primary scale block**
+
+Find:
+```css
+    /* /quieter — primary green stays as the neon driver, but on light
+     * we need a darker variant for "ink" (text/links) so the green
+     * doesn't get washed out against paper. */
+    --color-primary: #BBFD3B;          /* unchanged: action color */
+    --color-primary-dark-1: #A8E632;
+    --color-primary-dark-2: #6FA118;   /* link-on-paper green */
+    --color-primary-dark-3: #5A8413;
+    --color-primary-dark-4: #45660F;   /* visited link */
+    --color-primary-contrast: #1a1a1a;
+```
+
+Replace with:
+```css
+    /* /normalize — committed ink-on-paper scale that passes WCAG AA.
+     * Action surfaces (button bg, current-tab) stay fluorescent;
+     * dark-* scale is the "ink" variant for text on cream paper.
+     * All dark-* values verified ≥4.5:1 against --color-body. */
+    --color-primary: #BBFD3B;          /* action: button bg, 13.8:1 with #1a1a1a text */
+    --color-primary-contrast: #1a1a1a;
+    --color-primary-hover: #93C82B;    /* button hover bg, 8.45:1 with text */
+    --color-primary-active: #7AAB1F;   /* button active bg, 6.20:1 with text */
+    --color-primary-dark-1: #4D7008;   /* repo header counts, label text — 4.92:1 AA */
+    --color-primary-dark-2: #3D5A09;   /* link rest — 6.79:1 AA */
+    --color-primary-dark-3: #2C4D08;   /* link hover — 8.22:1 AAA */
+    --color-primary-dark-4: #1A2D04;   /* visited link — 12.5:1 AAA */
+    /* Override visible alpha tokens (reaction bg) so they match new dark-2 */
+    --color-primary-alpha-20: rgba(61, 90, 9, 0.20);
+    --color-primary-alpha-30: rgba(61, 90, 9, 0.30);
+```
+
+- [ ] **Step 3: Tighten `--color-text-light`**
+
+Find:
+```css
+    /* /harden — text contrast on paper.
+     * #595959 on #fbfaf7 → 7.0:1 (passes AAA normal text) */
+    --color-text: #1a1a1a;
+    --color-text-light: #595959;       /* AAA */
+```
+
+Replace with:
+```css
+    /* /harden — text contrast on paper.
+     * Tightened text-light to #4a4a4a for safer margin on highlighted
+     * surfaces (was #595959 → 4.84:1 on #ddd8c5; now 5.84:1). */
+    --color-text: #1a1a1a;
+    --color-text-light: #4a4a4a;       /* AAA on body, AA+ on every surface */
+```
+
+- [ ] **Step 4: Update backdrop-filter fallback**
+
+Find:
+```css
+@supports not ((backdrop-filter: blur(20px)) or (-webkit-backdrop-filter: blur(20px))) {
+    .full.height > .ui.menu,
+    .ui.modal,
+    .ui.modals.dimmer {
+        background-color: rgba(251, 250, 247, 0.97) !important;
+    }
+}
+```
+
+Replace with:
+```css
+@supports not ((backdrop-filter: blur(20px)) or (-webkit-backdrop-filter: blur(20px))) {
+    .full.height > .ui.menu,
+    .ui.modal,
+    .ui.modals.dimmer {
+        /* matches new --color-body #efece1 (PR #87 changed body, this
+         * fallback wasn't kept in sync) */
+        background-color: rgba(239, 236, 225, 0.97) !important;
+    }
+}
+```
+
+- [ ] **Step 5: Update focus-visible outline color**
+
+Find:
+```css
+/* /quieter — focus ring uses dark-3 (one step darker than link rest at
+ * dark-2) so it's visibly distinct without going lighter where AA contrast
+ * against #efece1 cream paper would fail. 3px offset for AA visibility. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+.ui.button:focus-visible,
+.ui.dropdown:focus-visible {
+    outline: 2px solid var(--color-primary-dark-3);
+    outline-offset: 3px;
+}
+```
+
+Replace with:
+```css
+/* /normalize — focus ring uses non-green teal #0e7b75 to break the
+ * focus-vs-hover collision (both were dark-3 forest green previously).
+ * 4.34:1 against body, passes 3:1 non-text minimum on every surface.
+ * Hue distinction (cyan ~180° vs yellow-green ~80°) gives keyboard
+ * users a clear "focus" signal regardless of hover state. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+.ui.button:focus-visible,
+.ui.dropdown:focus-visible {
+    outline: 2px solid #0e7b75;
+    outline-offset: 3px;
+}
+```
+
+- [ ] **Step 6: Verify final CSS state**
+
+Use Read tool on the entire override block (lines 14-160 — file is ~140 lines after edits). Visually scan for: balanced braces, no duplicate token definitions in the same `:root`, all comments updated, all 5 changed regions present (primary scale block, text-light, backdrop-filter fallback, focus-visible). Steps 4 and 5 modify lines past 100, so reading 14-50 alone misses them — must read full file.
+
+- [ ] **Step 7: Stage + commit**
+
+```bash
+git add custom/public/assets/css/theme-hackforger-light.css
+git -c commit.gpgsign=false commit -m "fix(theme/light): WCAG AA link colors + uncouple button hover
+
+User reported /explore/repos links unreadable on light theme. Audit
+measured PR #84 link rest at 2.62:1 (FAILS AA). Fix:
+
+- New dark-* scale: dark-2 = #3D5A09 (link rest, 6.79:1), dark-3 = #2C4D08
+  (hover, 8.22:1), dark-4 = #1A2D04 (visited, 12.5:1)
+- Uncouple button hover: --color-primary-hover = #93C82B (was inherited
+  as dark-2 from bundled, would have made buttons jump fluorescent →
+  forest green on hover)
+- Focus ring: teal #0e7b75 (distinct hue from any link state — keyboard
+  users can tell focus apart from hover)
+- text-light tightened #595959 → #4a4a4a (more AA margin on highlights)
+- Backdrop-filter fallback synced to PR #87's new body color
+- Override visible primary-alpha-20/30 to match new dark-2 (reaction bg)
+
+Dark theme untouched — audit confirmed bundled mint scale works.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Push, open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/light-link-readability
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base v0.1-dev/hackforger --head fix/light-link-readability \
+  --title "fix(theme/light): WCAG AA link readability on cream paper" \
+  --body "$(cat <<'PRBODY'
+## Summary
+
+Hotfix for user-reported defect on \`/explore/repos\`: link text was unreadable. Audit measured PR #84 link rest at **2.62:1** contrast against the cream body — far below WCAG AA's 4.5:1 minimum. This PR replaces the entire light-theme primary-dark-* scale with values that pass AA, while keeping the brand fluorescent green as the action surface color.
+
+Implements: \`docs/superpowers/specs/2026-04-21-light-link-readability-design.md\`
+
+## Changes
+
+- **Link rest**: \`#6FA118\` (2.62:1 ❌) → \`#3D5A09\` (**6.79:1 ✓ AA**)
+- **Link hover**: \`#5A8413\` (3.77:1 ❌) → \`#2C4D08\` (**8.22:1 ✓ AAA**)
+- **Button hover bg**: explicitly overridden to stay in fluorescent family (was silently inheriting from dark-2 = ink color, would have jumped to forest on hover)
+- **Focus ring**: teal \`#0e7b75\` (was dark-3 = same as hover; now distinct)
+- **text-light**: \`#595959\` → \`#4a4a4a\` (more AA margin on highlights)
+- **Backdrop-filter fallback**: synced to PR #87's new body color
+- **Reaction bg alpha tokens**: overridden to match new ink scale
+
+## Test plan
+
+- [ ] Hard-refresh \`/explore/repos\` — repo names and owner names readable forest-green ink
+- [ ] Same on \`/explore/issues\`, \`/explore/users\`, \`/explore/organizations\`
+- [ ] Repo's \`/issues\` list — issue titles readable
+- [ ] Repo file tree — file/dir names readable
+- [ ] Hover any link — visibly darkens (clear "more attention" signal)
+- [ ] Click a primary button — fluorescent fill preserved
+- [ ] Hover the same button — stays in fluorescent family (one notch darker), not jarring
+- [ ] Tab through a form — focus ring is teal, distinguishable from hover
+- [ ] Dark theme: no visual changes (regression check)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PRBODY
+)"
+```
+
+---
+
+### Task 5: Admin merge + restart hand-off
+
+User has authorized admin-merge in advance.
+
+- [ ] **Step 1: PR diff sanity check**
+
+```bash
+gh pr diff <PR-NUMBER> --repo HackForger/hackforger | head -80
+```
+
+Expected: 1 file (`custom/public/assets/css/theme-hackforger-light.css`), ~30 changed lines all in the override block region. STOP if any other file appears.
+
+- [ ] **Step 2: Admin merge**
+
+```bash
+gh pr merge <PR-NUMBER> --repo HackForger/hackforger --merge --admin --delete-branch
+```
+
+- [ ] **Step 3: Pull main with rebase**
+
+```bash
+cd /Users/h2oslabs/Workspace/hackforger
+git pull --rebase origin v0.1-dev/hackforger
+```
+
+- [ ] **Step 4: Identify gitea PID**
+
+```bash
+ps aux | grep -E '[g]itea web' | grep -v grep | awk '{print "PID: " $2}'
+```
+
+Print PID and tell user:
+> "Found gitea PID: `<pid>`. Please run `! kill <pid>` in your shell to stop it; I'll restart immediately after."
+
+- [ ] **Step 5: After user kills, clean lock + restart**
+
+```bash
+rm -f data/queues/common/LOCK
+nohup ./gitea web > /tmp/gitea.log 2>&1 &
+disown
+sleep 5
+```
+
+Then read `/tmp/gitea.log` (Read tool, not `tail`) and confirm `Listen: http://0.0.0.0:3000`.
+
+- [ ] **Step 6: Hand off to user**
+
+Tell user: "Instance restarted. Hard-refresh `localhost:3000` (Cmd+Shift+R), then verify on `/explore/repos` that link text is now readable forest green."
+
+---
+
+## Self-review checklist
+
+- [x] All 5 spec defects mapped to a step (CRIT-1/2 → Step 2, CRIT-3 → Step 5, LOW-2 → Step 4, HIGH-4 → Step 3).
+- [x] Reviewer-flagged issues addressed:
+  - `--color-primary-hover/active` overridden (Step 2)
+  - `dark-1` darkened so text uses pass AA (Step 2)
+  - Teal swapped to `#0e7b75` for chromatic distinction (Step 5)
+  - Visible alpha tokens overridden (Step 2)
+  - Grep step added (Task 2)
+- [x] Dark theme explicitly NOT modified (audit confirmed it works).
+- [x] Single CSS file change → one commit, one PR.
+- [x] PR diff sanity check before merge (Task 5 Step 1).
+- [x] Hand-off pattern: agent prints PID → user `! kill` → agent restarts.

--- a/docs/superpowers/specs/2026-04-21-light-link-readability-design.md
+++ b/docs/superpowers/specs/2026-04-21-light-link-readability-design.md
@@ -1,0 +1,191 @@
+# Light Theme Link Readability Hotfix — Design Spec
+
+**Date:** 2026-04-21
+**Branch:** fix/light-link-readability (will be created)
+**Predecessor:** PR #87 (light header + favicon)
+**Triggered by:** User report on `/explore/repos` — "fluorescent green text almost unreadable"
+**Audit basis:** `/impeccable:audit` Q2 report (this conversation)
+
+## 1. Problem
+
+PR #84 introduced a light theme `--color-primary-dark-*` override scale designed for dark-theme symmetry. On cream paper (`#efece1`), this scale fails WCAG AA across the board:
+
+| Token | Value | Contrast on `#efece1` | WCAG AA (4.5:1)? |
+|---|---|---|---|
+| `--color-primary-dark-1` | `#A8E632` | 1.85:1 | ❌ FAIL |
+| `--color-primary-dark-2` (link rest) | `#6FA118` | **2.62:1** | ❌ FAIL |
+| `--color-primary-dark-3` (link hover, focus) | `#5A8413` | **3.77:1** | ❌ FAIL |
+| `--color-primary-dark-4` (visited) | `#45660F` | 5.63:1 | ✓ pass |
+
+Symptom: every link on every list-heavy page (explore/repos, issue lists, file trees, commit logs) is unreadable. The `/explore/repos` page is the most acute because ~80% of its visible content is link text (repo names, owner names, language tags).
+
+Three secondary defects compound the problem:
+
+- **Focus ring uses the same color as hover** (both `#5A8413`) — keyboard users cannot distinguish focus from hover state.
+- **Backdrop-filter fallback** still references the pre-PR-#87 body color `rgba(251, 250, 247, 0.97)` — modal background no longer matches body on browsers without `backdrop-filter`.
+- **`--color-text-light` (`#595959`)** lands at exactly 4.84:1 against `--color-box-body-highlight` (`#ddd8c5`) — barely AA, no margin.
+
+## 2. Goals & Non-Goals
+
+### Goals
+- Every link text combination on light theme passes WCAG AA (4.5:1) against every surface it appears on.
+- Focus ring is visually distinct from both link rest and link hover.
+- Backdrop-filter fallback matches the actual body color.
+- Brand identity preserved: fluorescent `#BBFD3B` stays as the action-surface color (button fills, current-tab indicators), only the **ink scale** (text on paper) shifts to deeper greens.
+
+### Non-Goals
+- No dark theme changes (audit confirmed dark inherits a working bundled mint scale).
+- No `--color-secondary` rename (MED-1, separate spec).
+- No automated CI contrast checker (short-term recommendation, separate task).
+- No focus-ring redesign beyond color (the 2px outline + 3px offset structure is fine).
+
+## 3. Architecture
+
+### 3.1 The "ink vs neon" rule
+
+DESIGN.md positions `#BBFD3B` as the high-energy action color ("the neon pulse"). On dark theme that color works as link/text because the deep-black surface gives it 13:1 contrast. On cream paper, the same color drops to 1.85:1.
+
+The fix is to keep two parallel scales for light theme:
+
+- **Action scale** (button fills, current-state highlights): `--color-primary: #BBFD3B`. Bright, draws the eye to clickable surfaces. Text overlaid on these uses `--color-primary-contrast: #1a1a1a` (verified 13.8:1).
+- **Ink scale** (link text, focus rings on text): `--color-primary-dark-2/3/4`, all dark forest greens that pass AA on cream. This is what the original Forgejo bundled values approximated; we make them slightly more saturated to keep the "green brand" feeling.
+
+This is what DESIGN.md actually wanted. PR #84 conflated them, treating one variable for both meanings. This spec separates them.
+
+### 3.2 New light primary-dark-* scale + uncoupled hover/active
+
+**Critical correction from reviewer pass:** the bundled light theme defines `--color-primary-hover: var(--color-primary-dark-2)` and `--color-primary-active: var(--color-primary-dark-4)`. Without overriding these, changing `dark-2` would also change button hover background — and a fluorescent button suddenly turning near-black-green on hover is jarring. So we **uncouple them** with explicit overrides.
+
+Also: reviewer found `--color-primary-dark-1` is consumed as **text color** in `web_src/css/repo/header.css:50,63` and `web_src/css/modules/label.css:141`, not just as background. So `dark-1` must also pass AA on cream paper.
+
+**Final scale:**
+
+| Token | New value | Used as | Contrast on `#efece1` | WCAG |
+|---|---|---|---|---|
+| `--color-primary` | `#BBFD3B` | Button bg, current-tab fill | with `#1a1a1a` text: 13.8:1 | ✓ AAA |
+| `--color-primary-contrast` | `#1a1a1a` | Text on primary surfaces | (paired above) | ✓ AAA |
+| **`--color-primary-hover`** *(new override)* | `#93C82B` | Button hover bg | with `#1a1a1a` text: 8.45:1 | ✓ AAA |
+| **`--color-primary-active`** *(new override)* | `#7AAB1F` | Button active bg | with `#1a1a1a` text: 6.20:1 | ✓ AA |
+| `--color-primary-dark-1` | `#4D7008` | Repo header counts, primary label text | as text on body: **4.92:1** | ✓ AA |
+| `--color-primary-dark-2` | `#3D5A09` | **Link rest** | as text on body: **6.79:1** | ✓ AA |
+| `--color-primary-dark-3` | `#2C4D08` | Link hover, button-hover-deeper | as text on body: **8.22:1** | ✓ AAA |
+| `--color-primary-dark-4` | `#1A2D04` | Visited link | as text on body: **12.5:1** | ✓ AAA |
+
+The dark-1 → dark-4 progression is now a smooth darkening (all four work as text on cream), with the action color (`primary` + `primary-hover` + `primary-active`) staying as bright fluorescents on a separate axis — they're never used as text-on-paper, only as paint on action buttons.
+
+### 3.3 Primary-alpha tokens (visible drift fix)
+
+Bundled `--color-primary-alpha-20` and `-alpha-30` use the literal hex `#18805C` (bundled forest teal), and they drive `--color-reaction-hover-bg` / `--color-reaction-active-bg`. After our other changes, reactions would tint slightly teal while everything else is yellow-green ink — visible mismatch.
+
+Override only the two visible ones:
+
+```css
+--color-primary-alpha-20: rgba(61, 90, 9, 0.20);   /* matches new dark-2 */
+--color-primary-alpha-30: rgba(61, 90, 9, 0.30);
+```
+
+Skip alpha-10/40/50/60+ — they're either invisible at low opacity or unused in user-facing surfaces.
+
+### 3.4 Focus ring color
+
+Move from `--color-primary-dark-3` (same as hover) to a non-green hue: teal `#0e7b75`.
+
+Why teal: it's already in our colorize palette as `--color-cyan` (light theme defines `--color-cyan: #0d8b86`). We use a moderate darkening (`#0e7b75`) — reviewer flagged that pure-dark teal `#0a6b67` might read as "yet another dark color" next to the new dark-3 forest green. The mid-tone teal `#0e7b75` keeps chromatic distinction (cyan ~180° vs yellow-green ~80° hue separation) while still passing 3:1 non-text minimum.
+
+Contrast against our 5 surfaces:
+- on `#efece1` body: 4.34:1
+- on `#e3decd` header: 3.85:1
+- on `#e7e3d4` nav: 4.07:1
+- on `#ddd8c5` highlight: 3.54:1
+- on `#f6f3e9` card: 4.69:1
+
+All pass 3:1 non-text minimum. Keyboard users now see: link rest = forest ink → hover = darker forest ink → focus = visibly distinct teal outline. Three distinct states, no collision.
+
+### 3.5 Backdrop-filter fallback
+
+```css
+/* Before */
+@supports not (...) {
+    .full.height > .ui.menu, .ui.modal, .ui.modals.dimmer {
+        background-color: rgba(251, 250, 247, 0.97) !important;
+    }
+}
+
+/* After — matches new --color-body */
+@supports not (...) {
+    .full.height > .ui.menu, .ui.modal, .ui.modals.dimmer {
+        background-color: rgba(239, 236, 225, 0.97) !important;
+    }
+}
+```
+
+### 3.6 `--color-text-light` tightening
+
+Currently `#595959`. On `--color-box-body-highlight` (`#ddd8c5`), contrast is 4.84:1 — passes AA but with only 0.34 margin. Tighten to `#4a4a4a`:
+
+- on `#efece1` body: 7.39:1 (was 5.95:1)
+- on `#e7e3d4` nav: 6.66:1 (was 5.32:1)
+- on `#ddd8c5` highlight: 5.84:1 (was 4.84:1) — solid AA margin
+- on `#e3decd` header: 6.36:1
+- on `#f6f3e9` card: 7.83:1
+
+All pass AA with healthy margin; some pass AAA.
+
+## 4. File-by-file changes
+
+### `custom/public/assets/css/theme-hackforger-light.css`
+
+Find the `:root { ... --color-primary: #BBFD3B; ...}` block (lines ~31-39):
+- Update dark-1/2/3/4 to new values per §3.2.
+- ADD new lines: `--color-primary-hover: #93C82B;` and `--color-primary-active: #7AAB1F;` (uncouple button hover from link ink scale).
+- ADD: `--color-primary-alpha-20: rgba(61, 90, 9, 0.20);` and `--color-primary-alpha-30: rgba(61, 90, 9, 0.30);` per §3.3.
+
+Find the `:root` block containing `--color-text-light: #595959;` (line ~44) and change to `#4a4a4a`. Update the inline contrast comment.
+
+Find the focus-visible rule (line ~115 area) and change `outline: 2px solid var(--color-primary-dark-3)` to `outline: 2px solid #0e7b75`. Update the rationale comment per §3.4.
+
+Find the `@supports not (... backdrop-filter ...)` block (line ~98 area) and change `rgba(251, 250, 247, 0.97)` → `rgba(239, 236, 225, 0.97)`.
+
+### `custom/public/assets/css/theme-hackforger-dark.css`
+
+**No changes.** Audit confirmed dark theme inherits working values.
+
+## 5. Testing strategy
+
+Manual E2E only. After merge → restart `gitea web` → hard-refresh browser:
+
+### 5.1 Light theme (the bug under test)
+1. Navigate to `/explore/repos` (the user-reported page). Repo names and owner names should be readable dark-forest-green ink. Hover any link — visibly darkens.
+2. Navigate to `/explore/issues`, `/explore/users`, `/explore/organizations`. Same readability.
+3. Navigate to a repo's `/issues` list — issue titles readable.
+4. Navigate to a repo's file tree — file/dir names readable.
+5. Navigate to commit log — commit message links readable.
+6. Tab through a form (issue create) — focus ring is teal, visibly distinct from hover.
+7. Click a primary button — fluorescent fill preserved (brand identity intact).
+8. Open a modal on a browser without backdrop-filter (Safari < 9, hard to test) — modal bg matches body color (no white seam).
+
+### 5.2 Dark theme regression check
+1. Switch to dark theme. Repo names, issue titles, etc. — should look identical to before this PR. Mint-green scale untouched.
+2. Tab through form — focus ring still uses dark theme's color (which is `--color-primary-dark-1` per PR #87, not the new teal). **Important: the teal focus override is light-theme-scoped only.**
+
+### 5.3 Cross-browser smoke
+- Chrome: link colors render as expected.
+- Safari: same.
+- Firefox: same.
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `--color-primary-dark-1: #4D7008` used somewhere I haven't enumerated as text on cream — could fail | Reviewer pass identified `repo/header.css:50,63` and `label.css:141`. New dark-1 at 4.92:1 passes AA. Implementation plan adds a grep step to enumerate any other text consumers before merge. |
+| `--color-primary-alpha-10/40+` still drift to bundled forest teal — minor visual mismatch | Spec only fixes the visible alpha-20/30 (reaction backgrounds). Other alphas at 10% / 40%+ opacity are functionally invisible. Accepted. |
+| Teal focus ring breaks "green brand" consistency | Focus rings are functional UI not brand identity. Cyan is in DESIGN.md §2 secondary palette. If user objects, easy revert to `--color-primary-dark-4` (#1A2D04 = near-black green, 12.5:1 — also distinct from hover but stays in green family). |
+| `--color-text-light: #4a4a4a` darker than expected for "muted text" semantics | Subjective; if too dark, intermediate `#535353` (6.5:1 on body) is a fallback. |
+| Button hover/active going from fluorescent → bright-yellow-green-darker still feels "different" | This is the intentional fix. With explicit `--color-primary-hover: #93C82B` (one notch darker fluorescent) the transition stays in the same yellow-green family — user sees a darken, not a hue jump. |
+
+## 7. Out of scope (future work)
+
+- **CI contrast checker script.** Audit short-term recommendation. Would prevent this exact regression.
+- **`--color-secondary` rename to `--hf-surface-secondary`** (MED-1).
+- **Dark theme adopting DESIGN.md fluorescent as primary** (MED-2). Currently inherits mint.
+- **Visited link hue change** to non-green family (HIGH-1 from audit). With the new scale, visited at 12.5:1 already differentiates from rest at 5.11:1, so deferred.


### PR DESCRIPTION
## Summary

PR #88 shipped the light-theme link-readability hotfix (code + locale) but forgot to include its companion design docs. This PR retrofits:

- `docs/superpowers/specs/2026-04-21-light-link-readability-design.md` — the spec capturing WCAG AA contrast requirements, color decisions, and uncoupling of button hover from link ink
- `docs/superpowers/plans/2026-04-21-light-link-readability.md` — the step-by-step implementation plan that was followed when writing PR #88

Keeping the design history next to the code helps when revisiting theme decisions later.

No code changes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)