### PR TITLE
fix(rebrand): system.md SynNovator casing (#96 part 3)

### DIFF
--- a/custom/options/hackforger-help/system.en-US.md
+++ b/custom/options/hackforger-help/system.en-US.md
@@ -1,0 +1,45 @@
+# HackForger System Guide
+
+**HackForger** is the underlying system engine of the SynNovator platform. Built on Forgejo, it provides complete Git collaboration capabilities plus extension modules designed for co-creation activities. This page is a capability index — find the feature you need, then follow the link to go deeper.
+
+## Core Git Collaboration Capabilities
+
+These capabilities are inherited from Forgejo. Usage is identical to Forgejo / Gitea / GitHub:
+
+* **Repositories** — Create, Fork, branches, tags, protection rules, template repositories, mirror sync
+* **Pull Requests / Merge Requests** — Code review, conflict resolution, checks, auto-merge
+* **Issues** — Labels, milestones, project boards, automation, lock/pin
+* **Wiki / Project Docs** — Built-in repository Wiki, custom home page
+* **Forgejo Actions / Workflows** — `.forgejo/workflows/*.yml` CI/CD, self-hosted runner support
+* **Full-text Search** — Multi-dimensional search across code, Issues, Commits, and Wiki
+* **Webhooks / External Integrations** — Push code/Issue events to Slack, WeCom, external CI, and more
+* **SSH / HTTPS Access** — Personal Access Token (PAT), SSH key management
+* **Organizations / Teams** — Multi-level permissions, shared team repositories
+
+If you are familiar with GitHub, the workflows here are nearly identical. For detailed usage documentation, refer to the upstream [Forgejo Docs](https://forgejo.org/docs/latest/).
+
+## HackForger Platform Extension Modules
+
+These are the modules HackForger adds on top of Forgejo to power SynNovator's co-creation activities:
+
+| Module | Description | Access Path |
+|--------|-------------|-------------|
+| Hackathon | Event creation, registration, tracks, judges, scoring, leaderboard | `/explore/hackathons` |
+| Bounty | Issue linking, apply/claim, escrow, multi-party prize pool | `/explore/bounties` |
+| Grant | Funding rounds, project applications, review, allocation | `/explore/grants` |
+| Credits | Platform-wide credits ledger, redemption store, order history | `/credits` |
+| Submissions | Aggregated browsing of submissions across all activities | `/explore/submissions` |
+| Feed | Activity/Bounty/Grant/Credits event stream | `/` dashboard |
+| Reputation | User participation metrics, leaderboard, tier badges | `/explore/reputation` |
+
+## Developer Resources
+
+* **API Reference** — Visit `/api/swagger` for the full OpenAPI documentation; HackForger-specific endpoints start with `/api/v1/hackforger/`
+* **CLI Tool** — `hackforger-cli` (repository root, Go implementation, for bulk creation and management of activities)
+* **AI Agent Integration** — Authorize via PAT to let an AI agent operate the platform API on your behalf
+
+## Need Help?
+
+* Platform feature questions — Read the "Platform Guide (SynNovator)" section on this page
+* Git / repository questions — Refer to [Forgejo Docs](https://forgejo.org/docs/latest/)
+* Found a bug — Open an issue in the [HackForger GitHub repository](https://github.com/HackForger/hackforger/issues)

--- a/custom/options/hackforger-help/system.zh-CN.md
+++ b/custom/options/hackforger-help/system.zh-CN.md
@@ -1,0 +1,45 @@
+# HackForger 使用指南
+
+**HackForger** 是 SynNovator 平台的底层系统引擎，基于 Forgejo 构建，提供完整的 Git 协作能力，并加入了面向协创活动的扩展模块。本页是能力清单 —— 找到你需要的功能，按链接深入。
+
+## Git 协作基础能力
+
+这些能力继承自 Forgejo，使用方法与 Forgejo / Gitea / GitHub 一致：
+
+* **仓库 (Repositories)** — 创建、Fork、分支、标签、保护规则、模板仓库、镜像同步
+* **Pull Request / 合并请求** — 代码评审、冲突解决、检查、自动合并
+* **Issue / 议题** — 标签、里程碑、看板、自动化、锁定/置顶
+* **Wiki / 项目文档** — 仓库内置 Wiki、自定义主页
+* **Forgejo Actions / 工作流** — `.forgejo/workflows/*.yml` CI/CD，自托管 runner 支持
+* **全文搜索** — 代码、Issue、Commit、Wiki 多维度搜索
+* **Webhook / 外部集成** — 推送代码/Issue 等事件到 Slack、企微、外部 CI 等
+* **SSH / HTTPS 访问** — 个人访问令牌 (PAT)、SSH key 管理
+* **组织 / 团队** — 多级权限、团队仓库共享
+
+如果你熟悉 GitHub，这里的操作习惯几乎完全一致。详细使用文档可参考上游 [Forgejo Docs](https://forgejo.org/docs/latest/)。
+
+## HackForger 平台扩展模块
+
+这些是 HackForger 在 Forgejo 之外新增的模块，用于支撑 SynNovator 的协创活动：
+
+| 模块 | 说明 | 访问路径 |
+|------|------|---------|
+| 黑客松 Hackathon | 活动创建、报名、赛道、评委、评分、排行榜 | `/explore/hackathons` |
+| 悬赏 Bounty | Issue 关联、申请/接单、托管、多人竞争奖金 | `/explore/bounties` |
+| 资助 Grant | 资助轮次、项目申请、评审、分配 | `/explore/grants` |
+| 积分 Credits | 平台统一积分账本、兑换商店、订单记录 | `/credits` |
+| 提交作品 Submissions | 跨活动的作品聚合浏览 | `/explore/submissions` |
+| 社区动态 Feed | 活动/悬赏/资助/积分事件流 | `/` 控制面板 |
+| 声誉 Reputation | 用户参与度量、排行榜、层级徽章 | `/explore/reputation` |
+
+## 开发者资源
+
+* **API 参考** — `/api/swagger` 查看完整 OpenAPI 文档；HackForger 专用接口以 `/api/v1/hackforger/` 开头
+* **CLI 工具** — `hackforger-cli`（仓库根目录，Go 实现，用于批量创建/管理活动）
+* **AI Agent 集成** — 通过 PAT 授权让 AI 代表用户操作平台 API
+
+## 需要帮助？
+
+* 平台功能问题 —— 阅读本页"SynNovator 平台玩法"区
+* Git / 仓库问题 —— 参考 [Forgejo Docs](https://forgejo.org/docs/latest/)
+* 发现 bug —— 在 [HackForger GitHub 仓库](https://github.com/HackForger/hackforger/issues) 提 issue


### PR DESCRIPTION
Companion to #100. Override system.{zh-CN,en-US}.md via custom/options/ to fix the remaining 3 Synnovator mentions inside the system markdown body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)