### PR TITLE
fix(rebrand): CONTRIBUTING.md template SynNovator (#96)

### DIFF
--- a/services/hackforger/hackathon.go
+++ b/services/hackforger/hackathon.go
@@ -256,7 +256,7 @@ const trackRepoContributingTemplate = `# How to submit / 如何提交作品 — 
 
 ## 中文
 
-这是 HackForger 上 **%s** 的赛道仓库（track repository）。
+这是 SynNovator 平台上 **%s** 活动的赛道仓库（track repository）。
 
 **用途**：本仓库用来收集本赛道的所有参赛作品，并作为评委评审的代码基线。
 
@@ -264,7 +264,7 @@ const trackRepoContributingTemplate = `# How to submit / 如何提交作品 — 
 1. 在 web 页面上 **fork 本仓库**
 2. 在你 fork 的版本里开发你的作品
 3. 完成后，向 **本仓库** 发起 Pull Request
-4. **回到 HackForger 的活动页面，提交你的作品并填上 PR 链接**
+4. **回到 SynNovator 的活动页面，提交你的作品并填上 PR 链接**
    — 这一步会创建 submission 记录并触发索引更新
 5. 之后你的提交会自动出现在 ` + "`SUBMISSIONS.md`" + ` 索引中
 
@@ -277,7 +277,7 @@ const trackRepoContributingTemplate = `# How to submit / 如何提交作品 — 
 
 ## English
 
-This is the track repository for **%s** on HackForger.
+This is the track repository for the **%s** event on SynNovator.
 
 **Purpose**: This repo collects all submissions for this track and serves as
 the code baseline for judges to review.
@@ -286,7 +286,7 @@ the code baseline for judges to review.
 1. **Fork this repo** in the web UI
 2. Develop your project in your fork
 3. When done, open a **Pull Request back to this repo**
-4. **Go back to the HackForger hackathon page and submit your work, pasting
+4. **Go back to the SynNovator event page and submit your work, pasting
    the PR URL** — this creates a submission record and triggers an index update
 5. Your submission will then appear automatically in ` + "`SUBMISSIONS.md`" + `
 


### PR DESCRIPTION
Cynthialime UAT-2 反馈：新建赛道仓库的 CONTRIBUTING.md 仍显示 HackForger。

Per two-name model, these are platform-context references (where activity lives) → should be SynNovator. Updated 4 occurrences in services/hackforger/hackathon.go template constant.

⚠️ Only affects NEW tracks created after binary rebuild. ~30 existing repos won't be retro-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)