### PR TITLE
feat(skill): portable Agent Skills format for hackforger-api (#77)

### DIFF
--- a/skills/hackforger-api/INSTALL.md
+++ b/skills/hackforger-api/INSTALL.md
@@ -1,0 +1,59 @@
+# Install hackforger-api skill
+
+This skill follows the [Agent Skills standard](https://agentskills.io) — the same format read by Claude Code, OpenAI Codex CLI, Cursor, Gemini CLI, GitHub Copilot, and 30+ other clients. Each client decides its own install path (e.g. `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`), so the cleanest install is to **ask your agent to install itself**.
+
+## One-line install (recommended)
+
+Open your agent (Claude Code / Codex / Cursor / etc.) and paste:
+
+```
+请帮我安装这个 skill：https://github.com/HackForger/hackforger/tree/v0.1-dev/hackforger/skills/hackforger-api
+
+把 SKILL.md 和 references/ 目录放进你的 skill 安装目录（按你这个 client 的约定决定路径），
+完成后告诉我安装到了哪个路径。
+```
+
+Or in English:
+
+```
+Please install this skill for yourself:
+https://github.com/HackForger/hackforger/tree/v0.1-dev/hackforger/skills/hackforger-api
+
+Fetch SKILL.md and the references/ directory and place them in your client's
+skill install path (you know the convention for your platform). Tell me where
+you installed it when done.
+```
+
+The agent fetches the GitHub URL, reads SKILL.md + references/ contents, and places them under whichever path that specific client uses. No platform-specific installer to maintain.
+
+## After install
+
+Set these env vars in your shell:
+
+```bash
+export FORGEJO_TOKEN=<personal-access-token>
+export FORGEJO_URL=https://hackforger.inside.h2os.cloud   # or your instance URL
+```
+
+Generate a token at `<FORGEJO_URL>/-/user/settings/applications`. Scope must
+include the resources you intend to touch.
+
+## Manual install (if your agent can't fetch URLs)
+
+1. Clone or download this repo
+2. Copy the `skills/hackforger-api/` directory to your client's skill path:
+   - **Claude Code** (project): `<repo>/.claude/skills/hackforger-api/`
+   - **Claude Code** (user): `~/.claude/skills/hackforger-api/`
+   - **OpenAI Codex CLI**: `~/.codex/skills/hackforger-api/`
+   - **Cursor**: `~/.cursor/skills/hackforger-api/`
+   - **Other clients**: see your client's documentation for its skill directory
+3. Restart your client (some clients cache the skill list at startup)
+4. Set env vars per the section above
+
+## What ships in this skill
+
+- `SKILL.md` — entry point, agent reads this on slash invocation
+- `references/` — module-by-module API reference docs the agent loads on demand
+  - `README.md`, `attachments.md`, `bounties.md`, `credits.md`,
+    `feed-search-reputation.md`, `gaps.md`, `grants.md`, `hackathons.md`,
+    `orgs.md`, `user-stories.md`

--- a/skills/hackforger-api/SKILL.md
+++ b/skills/hackforger-api/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: hackforger-api
+description: Call HackForger platform API endpoints (hackathons, bounties, grants, credits, submissions, judging, feed, search, reputation, orgs, attachments). Use whenever the user asks to query or manage HackForger platform resources via natural language. Auth via FORGEJO_TOKEN env var, base URL via FORGEJO_URL (defaults to https://hackforger.inside.h2os.cloud).
+---
+
+# HackForger API skill
+
+This skill lets you call any HackForger platform API endpoint via curl.
+Design principle: **every web user action has an API equivalent** — if a user
+can do it in the browser, you can do it through this skill.
+
+## Authentication
+
+Set these env vars before invoking any endpoint:
+
+```bash
+export FORGEJO_TOKEN=<personal-access-token>      # required
+export FORGEJO_URL=https://hackforger.inside.h2os.cloud  # default; override for other instances
+```
+
+Generate a token at `<FORGEJO_URL>/-/user/settings/applications`. Scope must
+include the resources you intend to touch (e.g., `write:repository`,
+`admin:org` for org operations).
+
+## Calling an endpoint
+
+```bash
+curl -s -X $METHOD \
+  -H "Authorization: token $FORGEJO_TOKEN" \
+  -H "Content-Type: application/json" \
+  ${BODY:+-d "$BODY"} \
+  "${FORGEJO_URL:-https://hackforger.inside.h2os.cloud}/api/v1$PATH" | jq .
+```
+
+Examples:
+- List hackathons: `GET /hackforger/hackathons`
+- Create hackathon: `POST /hackforger/hackathons` with `{"name":"...","slug":"..."}`
+- Publish hackathon: `POST /hackforger/hackathons/{id}/publish`
+- List bounties on a repo: `GET /repos/{owner}/{repo}/bounties`
+- Apply for a grant: `POST /hackforger/grants/{round_id}/apply`
+
+For complete endpoint coverage by module, consult the `references/` directory:
+
+| File | Module |
+|------|--------|
+| `references/README.md` | Skill overview, design principle, E2E policy |
+| `references/hackathons.md` | Hackathon CRUD, tracks, criteria, registrations, submissions, judging, finalize, phases, **admin phase type catalog** |
+| `references/bounties.md` | Per-repo bounties: create, applications, review, complete, pay, cancel, winners |
+| `references/grants.md` | Grant rounds: round CRUD, projects, approve/award/distribute |
+| `references/credits.md` | Balance, transactions, redeem options + key pool, orders, admin deposit/deduct |
+| `references/feed-search-reputation.md` | Global feed, unified search, reputation leaderboard, **reputation settings (admin)**, assistant chat |
+| `references/orgs.md` | HackForger extensions to orgs: join-request notification |
+| `references/attachments.md` | Platform-level (RepoID=-1) rich-text uploads |
+| `references/user-stories.md` | E2E full-cycle user journey (Phase 0–10) → API call mapping |
+| `references/gaps.md` | API ↔ Web parity gaps (currently empty backlog) |
+
+Read the relevant `references/<module>.md` file when planning a multi-step
+chain (e.g., "create hackathon + tracks + criteria + phases + publish") so
+you don't miss a required step.
+
+## Common pitfalls
+
+1. **Hackathon publishing requires phases** — `POST /hackforger/hackathons/{id}/publish`
+   fails with 422 if zero phases exist. Always create at least one phase
+   (typically `registration` and `development`) before publishing.
+
+2. **Standard Forgejo operations vs HackForger operations** — fork, follow,
+   create-repo, create-org are Forgejo standard endpoints (`/api/v1/repos`,
+   `/api/v1/users`, `/api/v1/orgs`). HackForger-specific resources are under
+   `/api/v1/hackforger/...`. Use the right namespace.
+
+3. **E2E testing policy** — if the user asks for END-TO-END web testing
+   (clicking through the UI), DO NOT translate that into API calls. E2E must
+   exercise the actual web flow. API calls are appropriate for setup/teardown
+   and feature-level integration tests, not for E2E.
+
+4. **Live instance has real data** — the production-like instance at
+   `hackforger.inside.h2os.cloud` shares its DB with daily use. Don't assume
+   Forgejo test fixtures (`user2`, `repo1`, `user5`) exist. Query
+   `GET /repos/search` or `GET /users/search` to find real targets.
+
+## When the user asks to do something
+
+1. Identify which module the request touches (hackathons / bounties / grants / etc.)
+2. Read the corresponding `references/<module>.md` to confirm the endpoint and required body shape
+3. Construct the curl call(s)
+4. Execute, parse the JSON response, surface meaningful fields back to the user
+5. If the request is a chain (e.g., "create hackathon and publish"), execute steps in order and stop on first failure

--- a/skills/hackforger-api/references/README.md
+++ b/skills/hackforger-api/references/README.md
@@ -1,0 +1,28 @@
+# hackforger-api skill — references
+
+The `/hackforger-api` slash command (defined in `.claude/commands/hackforger-api.md`) is a thin curl wrapper. These reference documents catalogue the actual endpoints and how to chain them.
+
+## Files
+
+- **[hackathons.md](hackathons.md)** — Hackathon CRUD, tracks, criteria, registrations, submissions, judging, finalize, phases.
+- **[bounties.md](bounties.md)** — Per-repo bounties: create, applications, review, complete, pay, cancel, winners (competitive mode).
+- **[grants.md](grants.md)** — Grant rounds (Draft→Open→Review→Finalized→Distributed), project submissions, approve/award/distribute.
+- **[credits.md](credits.md)** — Balance, transactions, redeem options + key pool, redeem orders + fulfillment, admin deposit/deduct.
+- **[feed-search-reputation.md](feed-search-reputation.md)** — Global feed, unified search, reputation leaderboard, reputation algorithm settings, assistant chat.
+- **[orgs.md](orgs.md)** — HackForger extensions to orgs: join-request notification.
+- **[attachments.md](attachments.md)** — Platform-level (RepoID=-1) rich-text uploads.
+- **[user-stories.md](user-stories.md)** — E2E full-cycle user journey (Phase 0–10) mapped to API calls. Use this when a task is described in user-story form.
+- **[gaps.md](gaps.md)** — Web-only operations that lack API equivalents (backlog for parity).
+
+## Design principle
+
+HackForger holds the principle that **every web-facing user operation must have an API equivalent**. The web (SSR + Vue partial) is a UI form factor, not a capability boundary. Web-only operations are coverage gaps — see `gaps.md` for the current list.
+
+## E2E policy
+
+E2E tests must use the web UI via `agent-browser` (see `docs/tests/e2e/`). The existence of API parity does **not** mean E2E should switch to API — the policies are independent:
+
+- **API parity** ensures developers/scripts/CI/bots can drive the platform.
+- **E2E web testing** ensures the UI itself works for real users.
+
+Use this skill for: scripting, CI integration, dev fixtures, gap discovery, third-party automation. Do not use it as an E2E substitute.

--- a/skills/hackforger-api/references/attachments.md
+++ b/skills/hackforger-api/references/attachments.md
@@ -1,0 +1,32 @@
+# Attachments API
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/attachments` | Upload a platform-level (RepoID=-1) attachment for use in hackathon descriptions, grant project pages, and submission READMEs |
+
+## Why this exists
+
+Forgejo's standard attachment endpoints (`/repos/{owner}/{repo}/issues/{index}/assets`, `/releases/{id}/assets`) all force a repo / issue / release scope and persist `RepoID > 0`. HackForger needs attachments for content that isn't bound to any repo — hackathon descriptions, grant project pitches, etc. — so this endpoint produces an attachment with `RepoID = -1`.
+
+## Usage
+
+```bash
+curl -X POST \
+  -H "Authorization: token $FORGEJO_TOKEN" \
+  -F "file=@design.png" \
+  https://hackforger.inside.h2os.cloud/api/v1/hackforger/attachments
+# → {"uuid":"a3f8...e2c1"}
+```
+
+Reference the returned UUID in markdown like:
+```markdown
+![architecture diagram](/attachments/a3f8...e2c1)
+```
+
+## Errors
+
+| Status | Cause |
+|--------|-------|
+| 400 | File extension not in `setting.Attachment.AllowedTypes` |
+| 404 | Site attachment uploads disabled |
+| 401 | No token |

--- a/skills/hackforger-api/references/bounties.md
+++ b/skills/hackforger-api/references/bounties.md
@@ -1,0 +1,81 @@
+# Bounties API
+
+Bounties are scoped to a repo. Base path: `/api/v1/repos/{owner}/{repo}/bounties`.
+
+## Lifecycle
+
+State machine: **Open → Claimed → InReview → Completed → Paid** (or Cancelled / Expired)
+
+For competitive bounties: **Open → multiple applications → Winners selected → Paid**
+
+## CRUD
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/repos/{owner}/{repo}/bounties` | List bounties on a repo |
+| POST | `/repos/{owner}/{repo}/bounties` | Create bounty (escrow charged immediately) |
+| GET  | `/repos/{owner}/{repo}/bounties/{id}` | Get bounty |
+| PUT  | `/repos/{owner}/{repo}/bounties/{id}` | Update (Open only) |
+| DELETE | `/repos/{owner}/{repo}/bounties/{id}` | Delete (Open only) |
+
+## Rewards (competitive mode)
+
+| Verb | Path |
+|------|------|
+| GET  | `/repos/{owner}/{repo}/bounties/{id}/rewards` |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/rewards` |
+| DELETE | `/repos/{owner}/{repo}/bounties/{id}/rewards/{reward_id}` |
+
+## Applications
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/repos/{owner}/{repo}/bounties/{id}/applications` | List applications |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/applications` | Hacker applies |
+| PUT  | `/repos/{owner}/{repo}/bounties/{id}/applications/{application_id}` | Owner accepts/rejects (`{"action":"accept"}` → Open → Claimed) |
+
+## State transitions (owner actions)
+
+| Verb | Path | Transition |
+|------|------|------------|
+| POST | `/repos/{owner}/{repo}/bounties/{id}/review`  | Claimed → InReview (after delivery) |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/complete` | InReview → Completed |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/reject`   | InReview → Claimed (asks for redo) |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/pay`      | Completed → Paid (releases escrow) |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/cancel`   | Open/Claimed → Cancelled (refunds escrow) |
+| POST | `/repos/{owner}/{repo}/bounties/{id}/expire`   | Triggered by cron at deadline |
+
+## Competitive: select winners
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/repos/{owner}/{repo}/bounties/{id}/winners` | Select winners (`{"winners":[{"user_id":N,"reward_id":M}]}`) |
+| GET  | `/repos/{owner}/{repo}/bounties/{id}/winners` | List winners |
+
+After winners selected, call `/pay` to release multi-tier rewards.
+
+## Cross-repo discovery
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/bounties` | All bounties across the platform (with filters) |
+| GET  | `/hackforger/bounties/stats` | Aggregate stats |
+| GET  | `/hackforger/bounties/leaderboard` | Hunter leaderboard |
+
+## Common chains
+
+**Exclusive bounty (1 winner):**
+1. POST `/issues` (Forgejo stdlib — create issue first)
+2. POST `/bounties` `{"issue_id":..., "mode":"exclusive", "reward":100, "deadline":"..."}`
+3. POST `/applications` (hacker applies)
+4. PUT `/applications/{aid}` `{"action":"accept"}` (Open → Claimed)
+5. (Hacker forks, commits, opens PR)
+6. POST `/review` (PR ready)
+7. POST `/complete` then POST `/pay` (releases 100 credits to hacker)
+
+**Competitive bounty (multi-tier):**
+1. POST `/bounties` `{"mode":"competitive"}`
+2. POST `/rewards` `{"rank":1,"amount":150}` and `{"rank":2,"amount":100}`
+3. Multiple POST `/applications`
+4. POST `/winners` `{"winners":[{"user_id":U1,"reward_id":R1},{"user_id":U2,"reward_id":R2}]}`
+5. POST `/pay`

--- a/skills/hackforger-api/references/credits.md
+++ b/skills/hackforger-api/references/credits.md
@@ -1,0 +1,61 @@
+# Credits API
+
+Base path: `/api/v1/hackforger/credits`. All amounts are integers (credits).
+
+## User-facing
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/credits/balance` | Current balance for the authenticated user |
+| GET  | `/hackforger/credits/transactions` | Ledger (filter by type: deposit, bounty_pay, grant_award, hackathon_award, redeem, escrow_lock, escrow_release, manual) |
+
+## Redeem catalog (browse + buy)
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/credits/redeem/options` | List active redeem options (with stock) |
+| POST | `/hackforger/credits/redeem` | Redeem an option (creates pending order, deducts credits) |
+| GET  | `/hackforger/credits/redeem/orders` | User's order history (with assigned key once fulfilled) |
+
+## Admin: redeem option management
+
+Requires `reqSiteAdmin()`.
+
+| Verb | Path |
+|------|------|
+| POST | `/hackforger/credits/redeem/options` |
+| PUT  | `/hackforger/credits/redeem/options/{id}` |
+| GET  | `/hackforger/credits/redeem/options/{id}/keys` |
+| POST | `/hackforger/credits/redeem/options/{id}/keys` |
+
+## Admin: order fulfillment
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/credits/redeem/orders/{oid}/fulfill` | Mark single order fulfilled (assigns key from pool) |
+| POST | `/hackforger/credits/redeem/orders/fulfill` | Batch fulfill (`{"order_ids":[1,2,3]}`) |
+| POST | `/hackforger/credits/redeem/orders/{oid}/cancel` | Refund credits to user |
+
+## Admin: manual ledger adjustments
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/credits/admin/deposit` | Manual deposit (`{"user":"alice","amount":100,"reason":"..."}`) |
+| POST | `/hackforger/credits/admin/deduct` | Manual deduct |
+
+## Common chains
+
+**Hacker redeems GPU hours:**
+1. GET `/hackforger/credits/balance` (verify ≥ 200)
+2. GET `/hackforger/credits/redeem/options` (find option_id)
+3. POST `/hackforger/credits/redeem` `{"option_id":N}` (deducts 200, creates pending order)
+4. (Admin fulfills out-of-band: POST `/orders/{oid}/fulfill`)
+5. GET `/hackforger/credits/redeem/orders` (read assigned key from fulfilled order)
+
+**Admin sets up new redeem option + keys:**
+1. POST `/options` `{"name":"GPU Hours","price":200,"stock":10}`
+2. POST `/options/{id}/keys` `{"keys":["KEY-001","KEY-002",...]}`
+
+## Notes on transactions
+
+The ledger is append-only. Every state change in bounties/grants/hackathons writes a transaction with the appropriate `type` and references the originating entity. Use `GET /transactions?type=bounty_pay` etc. to filter for audit.

--- a/skills/hackforger-api/references/feed-search-reputation.md
+++ b/skills/hackforger-api/references/feed-search-reputation.md
@@ -1,0 +1,41 @@
+# Feed, Search, Reputation, Assistant
+
+## Feed
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/feed` | Activity feed (params: `scope=global|following|user|repo|org`, `actor_id`, `limit`, `cursor`) |
+
+Event types include: hackathon_published, hackathon_phase_changed, registered, submitted, scored, finalized; bounty_created, bounty_claimed, bounty_paid; grant_round_opened, grant_project_submitted, grant_distributed; redeem_fulfilled; followed; etc.
+
+## Unified search
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/search` | Cross-entity search (params: `q`, `kind=hackathon|bounty|grant|repo|user`, `limit`) |
+
+Backed by Bleve indexer. To force reindex (admin):
+```
+POST /hackforger/admin/reindex
+```
+
+## Reputation
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/reputation/users/{username}` | One user's reputation breakdown |
+| GET  | `/hackforger/reputation/leaderboard` | Top-N leaderboard (params: `limit`) |
+| POST | `/hackforger/reputation/recalculate/{username}` | Force recalculation (admin only) |
+
+### Reputation algorithm settings (admin)
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET | `/hackforger/admin/reputation/settings` | Read raw `weights` and `tiers` JSON |
+| PUT | `/hackforger/admin/reputation/settings` | Update one or both fields (partial update; non-empty fields must be valid JSON) |
+
+## Assistant chat
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/assistant/chat` | Chat with the platform assistant (`{"message":"..."}`) |

--- a/skills/hackforger-api/references/gaps.md
+++ b/skills/hackforger-api/references/gaps.md
@@ -1,0 +1,24 @@
+# API ↔ Web parity gaps
+
+Backlog of web-facing operations that have **no equivalent `/api/v1/hackforger/...` endpoint**. Per the project principle (every web user action must have an API equivalent), these should be filed and closed.
+
+## Real gaps
+
+> ✅ All 4 previously-listed gaps closed in PR #73 (commit `feat(api): close 4 hackforger API parity gaps`). The endpoints are now documented in:
+>
+> - `attachments.md` — `POST /hackforger/attachments`
+> - `feed-search-reputation.md` — `GET/PUT /hackforger/admin/reputation/settings`
+> - `hackathons.md` — phase type catalog CRUD (`/hackforger/admin/phase-types`)
+> - `orgs.md` — `POST /hackforger/orgs/{org}/join-request`
+>
+> Backlog is empty as of 2026-04-20.
+
+## How to consume this list
+
+When implementing a missing API:
+1. Add the route to `routers/api/v1/api.go` under the `/hackforger` group.
+2. Implement the handler in `routers/api/v1/hackforger/<module>.go` reusing the existing service-layer function (the web handler likely wraps the same service call).
+3. Add the new endpoint to the relevant module reference in this directory.
+4. Remove the row from this gaps file.
+
+> All listed gaps and dead-route cleanup items are closed as of 2026-04-20 (PR #73).

--- a/skills/hackforger-api/references/grants.md
+++ b/skills/hackforger-api/references/grants.md
@@ -1,0 +1,53 @@
+# Grants API
+
+Base path: `/api/v1/hackforger/grants`. State machine: **Draft → Open → Review → Finalized → Distributed**.
+
+## Round CRUD
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/grants` | List rounds (filter by status, organizer) |
+| POST | `/hackforger/grants` | Create round (Draft) |
+| GET  | `/hackforger/grants/{slug}` | Get round detail |
+| PUT  | `/hackforger/grants/{slug}` | Update (Draft only) |
+| DELETE | `/hackforger/grants/{slug}` | Delete (Draft only) |
+| GET  | `/hackforger/grants/{slug}/export` | CSV export |
+
+## Round transitions
+
+| Verb | Path | Transition |
+|------|------|------------|
+| POST | `/hackforger/grants/{slug}/open`       | Draft → Open (now accepting submissions) |
+| POST | `/hackforger/grants/{slug}/close`      | Open → Review (no more submissions) |
+| POST | `/hackforger/grants/{slug}/finalize`   | Review → Finalized (locks awards) |
+| POST | `/hackforger/grants/{slug}/distribute` | Finalized → Distributed (releases credits) |
+| POST | `/hackforger/grants/{slug}/cancel`     | Cancel from any non-distributed state (refunds) |
+
+## Project submissions
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/grants/{slug}/projects` | List projects in round |
+| POST | `/hackforger/grants/{slug}/projects` | Hacker submits project |
+| GET  | `/hackforger/grants/{slug}/projects/{pid}` | Get project |
+| PUT  | `/hackforger/grants/{slug}/projects/{pid}` | Approve/reject (`{"action":"approve"}` or `"reject"`) |
+| PUT  | `/hackforger/grants/{slug}/projects/{pid}/award` | Allocate award amount (`{"amount":300}`) |
+| POST | `/hackforger/grants/{slug}/projects/{pid}/distribute` | Distribute single project (alternative to round-level distribute) |
+
+## Common chains
+
+**Organizer round flow:**
+1. POST `/hackforger/grants` (Draft, with budget=500)
+2. POST `/hackforger/grants/{slug}/open`
+3. (Hackers POST `/projects` — multiple)
+4. POST `/hackforger/grants/{slug}/close`
+5. PUT `/projects/{pid}` `{"action":"approve"}` for selected
+6. PUT `/projects/{pid}/award` `{"amount":300}` (sum must ≤ budget)
+7. POST `/hackforger/grants/{slug}/finalize`
+8. POST `/hackforger/grants/{slug}/distribute` (releases credits, fires Feed events)
+
+## Constraints
+
+- `award` total across approved projects must not exceed `budget`. Server returns 422 with `ErrAwardExceedsBudget`.
+- Cannot reopen after `finalize`.
+- `distribute` is idempotent — calling twice is rejected with `ErrAlreadyDistributed`.

--- a/skills/hackforger-api/references/hackathons.md
+++ b/skills/hackforger-api/references/hackathons.md
@@ -1,0 +1,123 @@
+# Hackathons API
+
+Base path: `/api/v1/hackforger/hackathons`
+
+## Lifecycle (Draft → Open → Hacking → Judging → Finished)
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/hackathons` | Create hackathon (Draft) |
+| GET  | `/hackforger/hackathons` | List hackathons (filter via query) |
+| GET  | `/hackforger/hackathons/{id}` | Get hackathon detail |
+| PUT  | `/hackforger/hackathons/{id}` | Update hackathon fields |
+| DELETE | `/hackforger/hackathons/{id}` | Delete (Draft only) |
+| POST | `/hackforger/hackathons/{id}/publish` | Draft → Open |
+| POST | `/hackforger/hackathons/{id}/cancel` | Cancel hackathon |
+
+> **Phase advancement (Open → Hacking → Judging → Finished) is automatic.** A gocron scheduler (`hackforger_hackathon_status`, `@every 5m`) reads each hackathon's phase definitions and fires `onPhaseEvent` at start/end times. There is no API to manually advance — set phase `start_at`/`end_at` correctly via `/phases` and let the scheduler do it.
+
+## Tracks
+
+| Verb | Path |
+|------|------|
+| GET  | `/hackforger/hackathons/{id}/tracks` |
+| POST | `/hackforger/hackathons/{id}/tracks` |
+| PUT  | `/hackforger/hackathons/{id}/tracks/{tid}` |
+| DELETE | `/hackforger/hackathons/{id}/tracks/{tid}` |
+
+## Review criteria & rubric
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/hackathons/{id}/criteria` | List hackathon-level criteria |
+| POST | `/hackforger/hackathons/{id}/criteria` | Add criterion (weight, max score) |
+| PUT  | `/hackforger/hackathons/{id}/criteria/{cid}` | Update criterion |
+| DELETE | `/hackforger/hackathons/{id}/criteria/{cid}` | Delete criterion |
+| GET  | `/hackforger/hackathons/{id}/tracks/{tid}/criteria` | Effective rubric for a track (after overrides) |
+| PUT  | `/hackforger/hackathons/{id}/tracks/{tid}/criteria/{cid}` | Override criterion for a track |
+
+## Registrations
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/hackathons/{id}/register` | Hacker registers for a track |
+| GET  | `/hackforger/hackathons/{id}/registrations` | List registrations |
+| PUT  | `/hackforger/hackathons/{id}/registrations/{rid}` | Update (e.g. team, track) |
+
+## Submissions
+
+| Verb | Path |
+|------|------|
+| POST | `/hackforger/hackathons/{id}/submissions` |
+| GET  | `/hackforger/hackathons/{id}/submissions` |
+| GET  | `/hackforger/hackathons/{id}/submissions/{sid}` |
+| PUT  | `/hackforger/hackathons/{id}/submissions/{sid}` |
+| DELETE | `/hackforger/hackathons/{id}/submissions/{sid}` |
+
+## Judges & scoring
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/hackathons/{id}/judges` | List judges |
+| POST | `/hackforger/hackathons/{id}/judges` | Add judge |
+| DELETE | `/hackforger/hackathons/{id}/judges/{uid}` | Remove judge |
+| POST | `/hackforger/hackathons/{id}/submissions/{sid}/score` | Submit scores (judge) |
+| GET  | `/hackforger/hackathons/{id}/submissions/{sid}/scores` | List scores for a submission |
+| GET  | `/hackforger/hackathons/{id}/leaderboard` | Public leaderboard |
+
+## Finalization
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET  | `/hackforger/hackathons/{id}/finalize-preview` | Preview rankings before settle |
+| POST | `/hackforger/hackathons/{id}/finalize` | Confirm settlement (auto-distributes prize credits, advances to Finished) |
+
+## Phase definitions (timeline CRUD)
+
+These configure the *schedule* the cron uses. Editing a phase reschedules the gocron job for that hackathon.
+
+| Verb | Path |
+|------|------|
+| GET  | `/hackforger/hackathons/{id}/phases` |
+| POST | `/hackforger/hackathons/{id}/phases` |
+| POST | `/hackforger/hackathons/{id}/phases/reorder` |
+| PUT  | `/hackforger/hackathons/{id}/phases/{phase_id}` |
+| DELETE | `/hackforger/hackathons/{id}/phases/{phase_id}` |
+| GET  | `/hackforger/hackathons/{id}/current-phase` |
+
+## Common chains
+
+**Organizer setup → publish:**
+1. POST `/hackforger/hackathons` (Draft)
+2. POST `/hackforger/hackathons/{id}/tracks` (×N tracks)
+3. POST `/hackforger/hackathons/{id}/criteria` (×3+ criteria)
+4. POST `/hackforger/hackathons/{id}/judges` (assign judges)
+5. POST `/hackforger/hackathons/{id}/phases` (set schedule)
+6. POST `/hackforger/hackathons/{id}/publish`
+
+**Hacker journey:**
+1. POST `/hackforger/hackathons/{id}/register?track={tid}`
+2. (Wait for Hacking phase — automatic)
+3. POST `/hackforger/hackathons/{id}/submissions` (Fork+PR or Link Repo)
+4. (Wait for Judging → Finished — automatic)
+5. GET `/hackforger/credits/balance` (claim auto-distributed prize)
+
+**Judge journey:**
+1. (Wait for Judging phase)
+2. GET `/hackforger/hackathons/{id}/submissions` (filter assigned)
+3. POST `/hackforger/hackathons/{id}/submissions/{sid}/score` (×N submissions)
+
+## Admin: phase type catalog
+
+The **phase type catalog** is the global library of phase definitions (Registration, Development, Judging, etc.) that organizers pick from when configuring a hackathon's timeline. Per-hackathon `/phases` (above) creates *instances* from these types.
+
+Auth: `reqToken() + reqSiteAdmin()`.
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| GET | `/hackforger/admin/phase-types` | List all phase types (flat array) |
+| POST | `/hackforger/admin/phase-types` | Create (`activity_kind`, `key`, `display_name_i18n`, `is_unique`, `allowed_actions`, `default_order`) |
+| PUT | `/hackforger/admin/phase-types/{id}` | Full overwrite |
+| DELETE | `/hackforger/admin/phase-types/{id}` | Remove |
+
+`activity_kind` is one of `hackathon`, `bounty`, `grant`. `display_name_i18n` is an i18n **key** (e.g. `hackforger.phase.registration`), not display text — clients translate via locale.

--- a/skills/hackforger-api/references/orgs.md
+++ b/skills/hackforger-api/references/orgs.md
@@ -1,0 +1,33 @@
+# Orgs API (HackForger extensions)
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/hackforger/orgs/{org}/join-request` | Notify the org's owners that the authenticated user wants to join |
+
+## Semantics
+
+This is **fire-and-forget**. No `join_request` row is persisted; the operation only publishes a `ActionOrgJoinRequest` notification visible to the org's owners. Hence the `202 Accepted` response — there is no resource to GET later, only a side-effecting notification.
+
+To **accept** or **reject** a join request, use Forgejo's standard team membership API:
+
+| Forgejo standard | Use for |
+|------------------|---------|
+| `PUT /teams/{id}/members/{username}` | Add the user to a team (effectively accepts) |
+| `DELETE /teams/{id}/members/{username}` | Remove (or reject by inaction) |
+
+## Usage
+
+```bash
+curl -X POST \
+  -H "Authorization: token $FORGEJO_TOKEN" \
+  https://hackforger.inside.h2os.cloud/api/v1/hackforger/orgs/web3-innovation/join-request
+# → 202 {"status":"notified"}
+```
+
+## Errors
+
+| Status | Cause |
+|--------|-------|
+| 422 | The authenticated user is already a member of the org |
+| 404 | Org does not exist |
+| 401 | No token |

--- a/skills/hackforger-api/references/user-stories.md
+++ b/skills/hackforger-api/references/user-stories.md
@@ -1,0 +1,103 @@
+# E2E user stories → API mapping
+
+Audit of every step in `docs/tests/e2e/tasks/full-cycle/00-08-*.md` cross-referenced against `/api/v1/hackforger/*` (and Forgejo standard endpoints where the operation is generic).
+
+**Coverage status:**
+- ✅ — equivalent API endpoint exists and works
+- ⚠️ — partial coverage, see notes
+- ❌ — no API equivalent (see [gaps.md](gaps.md))
+- 🤖 — operation is automatic (cron/scheduler), no API call needed
+- 📦 — handled by Forgejo standard endpoints (not HackForger-specific)
+
+| Phase | Step | Action | API call | Status |
+|-------|------|--------|----------|--------|
+| **0 Setup** | 0.1 | Admin creates redeem option | `POST /hackforger/credits/redeem/options` | ✅ |
+| 0 | 0.2 | Admin adds API keys to pool | `POST /hackforger/credits/redeem/options/{id}/keys` | ✅ |
+| 0 | 0.3 | Admin deposits credits to user | `POST /hackforger/credits/admin/deposit` | ✅ |
+| **1 Hackathon setup** | 1.1 | Organizer creates hackathon (Draft) | `POST /hackforger/hackathons` | ✅ |
+| 1 | 1.2 | Organizer creates 2 tracks | `POST /hackforger/hackathons/{id}/tracks` ×2 | ✅ |
+| 1 | 1.3 | Organizer adds 3 review criteria per track | `POST /hackforger/hackathons/{id}/criteria` (+ track overrides) | ✅ |
+| 1 | 1.4 | Organizer assigns judges | `POST /hackforger/hackathons/{id}/judges` | ✅ |
+| 1 | 1.5 | Organizer publishes (Draft → Open) | `POST /hackforger/hackathons/{id}/publish` | ✅ |
+| **2 Registration** | 2.1 | Hacker follows organizer | `PUT /user/following/{username}` | 📦 |
+| 2 | 2.2 | Hacker registers for Web Track | `POST /hackforger/hackathons/{id}/register` | ✅ |
+| 2 | 2.3 | Hacker registers for DeFi Track | `POST /hackforger/hackathons/{id}/register` | ✅ |
+| 2 | 2.4 | Mutual follow (eve ↔ frank) | `PUT /user/following/{username}` | 📦 |
+| 2 | 2.5 | Organizer creates org team | `POST /orgs/{org}/teams` | 📦 |
+| 2 | 2.6 | Judge tries to register (rejected) | `POST /hackforger/hackathons/{id}/register` | ✅ |
+| **3 Hacking** | 3.1 | Phase advance Open → Hacking | (cron `hackforger_hackathon_status` @ phase boundary) | 🤖 |
+| 3 | 3.2 | Duplicate publish (rejected) | `POST /hackforger/hackathons/{id}/publish` | ✅ |
+| **4 Bounty** | 4.1 | Hacker forks repo + commit | `POST /repos/{owner}/{repo}/forks`, `POST /repos/{owner}/{repo}/contents/{path}` | 📦 |
+| 4 | 4.2 | Hacker creates issue | `POST /repos/{owner}/{repo}/issues` | 📦 |
+| 4 | 4.3 | Hacker creates exclusive bounty | `POST /repos/{owner}/{repo}/bounties` | ✅ |
+| 4 | 4.4 | Admin deposits credits (escrow support) | `POST /hackforger/credits/admin/deposit` | ✅ |
+| 4 | 4.5 | Other hacker applies for bounty | `POST /repos/{owner}/{repo}/bounties/{id}/applications` | ✅ |
+| 4 | 4.6 | Owner accepts application (Open → Claimed) | `PUT /repos/{owner}/{repo}/bounties/{id}/applications/{aid}` | ✅ |
+| 4 | 4.7 | Hacker forks + delivers files | `POST /repos/{owner}/{repo}/contents/{path}` | 📦 |
+| 4 | 4.8 | Hacker opens PR | `POST /repos/{owner}/{repo}/pulls` | 📦 |
+| 4 | 4.9 | Owner reviews + completes + pays (InReview → Completed → Paid) | `POST /bounties/{id}/review`, `/complete`, `/pay` | ✅ |
+| 4 | 4.10 | View balance | `GET /hackforger/credits/balance` | ✅ |
+| **5 Grant** | 5.1 | Admin deposits Grant budget | `POST /hackforger/credits/admin/deposit` | ✅ |
+| 5 | 5.2 | Organizer creates Grant Round (Draft) | `POST /hackforger/grants` | ✅ |
+| 5 | 5.3 | Organizer opens round (Draft → Open) | `POST /hackforger/grants/{slug}/open` | ✅ |
+| 5 | 5.4 | Hacker submits project A | `POST /hackforger/grants/{slug}/projects` | ✅ |
+| 5 | 5.5 | Hacker submits project B | `POST /hackforger/grants/{slug}/projects` | ✅ |
+| 5 | 5.6 | Organizer closes (Open → Review) | `POST /hackforger/grants/{slug}/close` | ✅ |
+| 5 | 5.7 | Organizer approves project A, rejects B + sets award | `PUT /grants/{slug}/projects/{pid}` + `PUT /award` | ✅ |
+| 5 | 5.8 | Organizer finalizes + distributes | `POST /finalize` + `POST /distribute` | ✅ |
+| 5 | 5.9 | Hacker views balance | `GET /hackforger/credits/balance` | ✅ |
+| **6 Submission** | 6.1 | Hacker continues development (commit) | `POST /repos/{owner}/{repo}/contents/{path}` | 📦 |
+| 6 | 6.2 | Hacker submits via Fork+PR mode | `POST /hackforger/hackathons/{id}/submissions` | ✅ |
+| 6 | 6.3 | Hacker forks DeFi track repo | `POST /repos/{owner}/{repo}/forks` | 📦 |
+| 6 | 6.4 | Hacker submits via Link Repo mode | `POST /hackforger/hackathons/{id}/submissions` | ✅ |
+| 6 | 6.5 | Star track repos | `PUT /user/starred/{owner}/{repo}` | 📦 |
+| **7 Judging** | 7.1 | Phase advance Hacking → Judging | (cron @ phase boundary) | 🤖 |
+| 7 | 7.2 | Judge1 scores all submissions | `POST /hackforger/hackathons/{id}/submissions/{sid}/score` | ✅ |
+| 7 | 7.3 | Judge2 scores all submissions | `POST /hackforger/hackathons/{id}/submissions/{sid}/score` | ✅ |
+| 7 | 7.4 | Organizer views finalize preview | `GET /hackforger/hackathons/{id}/finalize-preview` | ✅ |
+| 7 | 7.5 | Organizer confirms settlement (Judging → Finished) | `POST /hackforger/hackathons/{id}/finalize` | ✅ |
+| 7 | 7.6 | Hacker views balance change | `GET /hackforger/credits/balance` + `/transactions` | ✅ |
+| 7 | 7.7 | Hacker views balance change | `GET /hackforger/credits/balance` | ✅ |
+| 7 | 7.8 | View final leaderboard | `GET /hackforger/hackathons/{id}/leaderboard` | ✅ |
+| **8 Credits** | 8.1 | View credits + transaction history | `GET /balance` + `/transactions` | ✅ |
+| 8 | 8.2 | Browse redeem options | `GET /hackforger/credits/redeem/options` | ✅ |
+| 8 | 8.3 | Redeem GPU power (200 credits) | `POST /hackforger/credits/redeem` | ✅ |
+| 8 | 8.4 | Admin fulfills order (assigns key) | `POST /hackforger/credits/redeem/orders/{oid}/fulfill` | ✅ |
+| 8 | 8.5 | Hacker views fulfilled order + key | `GET /hackforger/credits/redeem/orders` | ✅ |
+| 8 | 8.6 | Admin manually deposits 500 | `POST /hackforger/credits/admin/deposit` | ✅ |
+| 8 | 8.7 | Admin manually deducts 50 | `POST /hackforger/credits/admin/deduct` | ✅ |
+| **9 Social/Feed** | 9.1 | View Following feed | `GET /hackforger/feed?scope=following` | ✅ |
+| 9 | 9.2 | View Global feed | `GET /hackforger/feed?scope=global` | ✅ |
+| 9 | 9.3 | Explore Hackathons | `GET /hackforger/hackathons` | ✅ |
+| 9 | 9.4 | Explore Bounties | `GET /hackforger/bounties` | ✅ |
+| 9 | 9.5 | Explore Grants | `GET /hackforger/grants` | ✅ |
+| 9 | 9.6 | Explore Submissions | `GET /hackforger/hackathons/{id}/submissions` (per-hackathon) | ✅ |
+| 9 | 9.7 | Global search (Cmd+K) | `GET /hackforger/search?q=...` | ✅ |
+| 9 | 9.8 | View Reputation leaderboard | `GET /hackforger/reputation/leaderboard` | ✅ |
+| 9 | 9.9 | Add reaction to PR | `POST /repos/{owner}/{repo}/issues/{index}/reactions` | 📦 |
+| **10 Edge** | 10a.1 | Create bounty with past deadline | `POST /repos/{owner}/{repo}/bounties` | ✅ |
+| 10 | 10a.2 | System triggers expiry | (cron `hackforger_bounty_expiry` @ deadline) | 🤖 |
+| 10 | 10b.1 | Cancel bounty (refund) | `POST /repos/{owner}/{repo}/bounties/{id}/cancel` | ✅ |
+| 10 | 10c.1 | Create competitive bounty (multi-tier) | `POST /bounties` + `POST /rewards` ×N | ✅ |
+| 10 | 10c.2 | Multiple users apply | `POST /applications` ×N | ✅ |
+| 10 | 10c.3 | Select winners + pay | `POST /winners` + `POST /pay` | ✅ |
+| 10 | 10d.1 | Try to add participant as judge (rejected) | `POST /hackforger/hackathons/{id}/judges` | ✅ |
+| 10 | 10d.2 | Duplicate registration (rejected) | `POST /hackforger/hackathons/{id}/register` | ✅ |
+| 10 | 10d.3 | Award > grant budget (rejected) | `PUT /grants/{slug}/projects/{pid}/award` | ✅ |
+| 10 | 10d.4 | Non-owner accesses manage page (403) | (any management endpoint) | ✅ |
+| 10 | 10d.5 | Apply to claimed exclusive bounty (rejected) | `POST /applications` | ✅ |
+| **Cross** | C.1 | Verify credits ledger consistency | `GET /transactions` for each user | ✅ |
+| Cross | C.2 | Verify all Feed events present | `GET /feed?scope=global` | ✅ |
+
+## Result
+
+**Every E2E user-story step has an API path.** Coverage breakdown:
+- ✅ HackForger-native API: 53 steps
+- 📦 Forgejo standard API (git/follow/star/reactions): 10 steps
+- 🤖 Automatic (cron-driven, no API call): 3 steps (3.1, 7.1, 10a.2)
+
+There are zero E2E steps that require a web-only operation, **provided phase transitions are tested by setting short phase durations and waiting for the cron**, rather than expecting a manual "advance phase" button (see [gaps.md](gaps.md) for the dead-route situation).
+
+## Note on E2E policy
+
+Per `feedback_e2e_web_mandatory`: E2E tests still go through the web UI via `agent-browser`. This mapping is for skill consumers (scripts, CI, dev fixtures) — not for replacing E2E.


### PR DESCRIPTION
Closes #77 (skill format issue).

## Why this PR

Tester (@Cynthialime) confirmed on #77 that our previous \`.skill\` zip with \`hackforger-api.md\` + \`INSTALL.md\` sidecar wrapper is **non-standard**. Codex's actual install path is \`~/.codex/skills/<name>/SKILL.md\` (uppercase entry file). She had to manually rewrite the bundle before Codex could use it.

## What this PR does

Adopts the [Agent Skills standard](https://agentskills.io) — Anthropic published Dec 2025, since adopted by Codex / Cursor / Gemini CLI / Copilot / 30+ clients. Same file format across all of them; only install paths differ.

New layout:

\`\`\`
skills/hackforger-api/
├── SKILL.md         # YAML frontmatter (name, description) + instructions
├── INSTALL.md       # how to install (agent-driven, see below)
└── references/      # 10 module reference docs
\`\`\`

## Install approach: agent-driven

Instead of shipping a multi-target \`install.sh\` (fragile when client conventions change), users paste a one-line prompt to their agent. The agent fetches the GitHub URL and places files into its own conventional skill directory. Works for any client that supports the Agent Skills standard.

\`\`\`
请帮我安装这个 skill：https://github.com/HackForger/hackforger/tree/v0.1-dev/hackforger/skills/hackforger-api
\`\`\`

## Out of scope (followup PR)

- Removing legacy \`.claude/skills/hackforger-api.md\`, \`.claude/commands/hackforger-api.md\`, and \`docs/skills/hackforger-api/\` — will clean up after tester verifies the new format works
- Cutting a new release tag with the new bundle

## Test plan

- [ ] Tester (Cynthialime) tries the agent-driven install in Codex on Windows
- [ ] Re-runs the 5 mandatory test scenarios from #77 issue body, confirming agent navigates references correctly
- [ ] Bonus scenarios 6/7/8 (E2E policy / Forgejo vs HackForger / gaps.md) also tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)