### PR TITLE
feat(landing): apply #112 text fixes + 12 schedule card titles from ops template

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -887,7 +887,7 @@ window.HACKFORGER_LANDING_CONFIG = {
   <li class="li5"><b>指导单位：</b>中共上海市委宣传部、上海市经济和信息化委员会、上海市数据局、上海市人才工作局、上海市科学技术委员会、共青团上海市委员会、中国（上海）自由贸易试验区临港新片区管理委员会</li>
   <li class="li5"><b>主办单位：</b>上海临港北京大学国际科技创新中心、南汇新城镇人民政府、临港新片区团工委</li>
   <li class="li5"><b>承办单位：</b>智道元生（上海）技术有限公司、中国电信股份有限公司上海分公司</li>
-  <li class="li5"><b>协办单位：</b>青年报社、上海临港科技创新城经济发展有限公司、上海市学生事务中心、上海市数字企业出海服务协会、上海临港新片区数字基建投资发展有限公司、上海智慧城市发展研究院、燕缘孵化器等</li>
+  <li class="li5"><b>协办单位：</b>青年报社、上海临港科技创新城经济发展有限公司、上海市数字企业出海服务协会、上海临港新片区数字基建投资发展有限公司、上海智慧城市发展研究院、燕缘孵化器</li>
   <li class="li5"><b>创投支持单位：</b>上海国投科创、上海国投未来、上海国投赋能、临港集团、临港青年创业基金、燕缘创投等</li>
 </ul>
 <p class="p6"><br></p>
@@ -947,7 +947,7 @@ window.HACKFORGER_LANDING_CONFIG = {
       <td valign="middle" class="td1">
         <p class="p10">AI实战训练营（线上&amp;线下）：7月27日</p>
         <p class="p10">协创松年度总决赛（线下）：7月28日至7月30日</p>
-        <p class="p10">颁奖典礼&amp;嘉年华（线下）：7月31日</p>
+        <p class="p10">颁奖活动&amp;嘉年华（线下）：7月31日</p>
       </td>
     </tr>
   </tbody>
@@ -1588,7 +1588,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S1-1.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">初赛/Wave 1</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 4.29-5.5</span>
@@ -1604,7 +1604,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 2" class="w-full h-full object-cover" src="assets/images/S1-2.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">复赛/Wave 2</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.7-5.9</span>
@@ -1620,7 +1620,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 3" class="w-full h-full object-cover" src="assets/images/S1-3.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">半决赛/Wave 3</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.14-5.16</span>
@@ -1636,7 +1636,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 4" class="w-full h-full object-cover" src="assets/images/S1-4.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">决赛/Wave 4</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#决赛 6.17-6.18</span>
@@ -1665,7 +1665,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S2-1.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">初赛/Wave 1</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.11-5.26</span>
@@ -1681,7 +1681,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 2" class="w-full h-full object-cover" src="assets/images/S2-2.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">复赛/Wave 2</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.28-5.30</span>
@@ -1697,7 +1697,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 3" class="w-full h-full object-cover" src="assets/images/S2-3.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">半决赛/Wave 3</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 6.4-6.6</span>
@@ -1713,7 +1713,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 4" class="w-full h-full object-cover" src="assets/images/S2-4.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">决赛/Wave 4</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#决赛 6.17-6.18</span>
@@ -1745,7 +1745,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S3-1.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">初赛/Wave 1</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.11-6.24</span>
@@ -1761,7 +1761,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 2" class="w-full h-full object-cover" src="assets/images/S3-2.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">复赛/Wave 2</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 7.1-7.3</span>
@@ -1777,7 +1777,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 3" class="w-full h-full object-cover" src="assets/images/S3-3.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">半决赛/Wave 3</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 7.10-7.12</span>
@@ -1793,7 +1793,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <img loading="lazy" decoding="async" alt="Wave 4" class="w-full h-full object-cover" src="assets/images/S3-4.webp"/>
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
-<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">决赛/Wave 4</h5>
+<h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】全球青年培育赛</h5>
 <div class="mb-6 flex items-center gap-2">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#6月-7月</span>
@@ -1850,7 +1850,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="text-[10px] md:text-xs font-black tracking-[0.28em] uppercase opacity-70 font-oppo">01 / GUIDANCE</div>
 <h3 class="text-xl md:text-2xl font-black tracking-tight font-oppo mt-1">指导单位</h3>
 </div>
-<div class="text-[10px] md:text-xs font-bold tracking-[0.2em] uppercase opacity-60 font-oppo">Directing Authorities · 7</div>
+<div class="text-[10px] md:text-xs font-bold tracking-[0.2em] uppercase opacity-60 font-oppo">Directing Authorities</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
 <span class="org-chip"><span class="org-chip-dot"></span>中共上海市委宣传部</span>
@@ -1870,7 +1870,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="text-[10px] md:text-xs font-black tracking-[0.28em] uppercase org-accent-text font-oppo">02 / HOSTS</div>
 <h3 class="text-xl md:text-2xl font-black tracking-tight text-on-surface font-oppo mt-1">主办单位</h3>
 </div>
-<div class="text-[10px] font-bold tracking-[0.2em] uppercase text-on-surface-variant opacity-60 font-oppo">Hosts · 3</div>
+<div class="text-[10px] font-bold tracking-[0.2em] uppercase text-on-surface-variant opacity-60 font-oppo">Hosts</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海临港北京大学国际科技创新中心</span>
@@ -1885,7 +1885,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="text-[10px] md:text-xs font-black tracking-[0.28em] uppercase org-accent-text font-oppo">03 / ORGANIZERS</div>
 <h3 class="text-xl md:text-2xl font-black tracking-tight font-oppo mt-1 text-white">承办单位</h3>
 </div>
-<div class="text-[10px] font-bold tracking-[0.2em] uppercase opacity-70 font-oppo text-white">Organizers · 2</div>
+<div class="text-[10px] font-bold tracking-[0.2em] uppercase opacity-70 font-oppo text-white">Organizers</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
 <span class="org-chip org-chip-onDark"><span class="org-chip-dot"></span>智道元生（上海）技术有限公司</span>
@@ -1900,12 +1900,11 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="text-[10px] md:text-xs font-black tracking-[0.28em] uppercase text-on-surface-variant font-oppo">04 / CO-ORGANIZERS</div>
 <h3 class="text-xl md:text-2xl font-black tracking-tight text-on-surface font-oppo mt-1">协办单位</h3>
 </div>
-<div class="text-[10px] font-bold tracking-[0.2em] uppercase text-on-surface-variant opacity-60 font-oppo">Co-organizers · 7+</div>
+<div class="text-[10px] font-bold tracking-[0.2em] uppercase text-on-surface-variant opacity-60 font-oppo">Co-organizers</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>青年报社</span>
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海临港科技创新城经济发展有限公司</span>
-<span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海市学生事务中心</span>
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海市数字企业出海服务协会</span>
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海临港新片区数字基建投资发展有限公司</span>
 <span class="org-chip org-chip-soft"><span class="org-chip-dot"></span>上海智慧城市发展研究院</span>
@@ -1919,7 +1918,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-5">
 <div class="text-[10px] md:text-xs font-black tracking-[0.28em] uppercase opacity-70 font-oppo">05 / VC SUPPORT</div>
 <h3 class="text-xl md:text-2xl font-black tracking-tight font-oppo mt-1">创投支持</h3>
-<div class="text-[10px] font-bold tracking-[0.2em] uppercase opacity-60 font-oppo mt-1">Venture Capital · 4+</div>
+<div class="text-[10px] font-bold tracking-[0.2em] uppercase opacity-60 font-oppo mt-1">Venture Capital</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
 <span class="org-chip"><span class="org-chip-dot"></span>上海国投</span>
@@ -2531,7 +2530,7 @@ window.HACKFORGER_LANDING_CONFIG = {
         },
         "rule-stage-04": {
                 "title": "Season 04 年度总决赛",
-                "md": "## 协创松 Buildathon 年度总决赛\n\n- 参赛人群：S1、S2、S3 联赛晋级团队（共60个团队），以及经官方评审具备同等产品能力的 AI+OPC 创业者，总共不超100个团队。\n- AI实战训练营：7月27日。\n- 协创松年度总决赛：7月28日至7月30日。\n- 颁奖典礼 & 嘉年华：7月31日。\n- 比赛形式：线下72小时协创马拉松 Buildathon，集中冲刺产品迭代、部署上线或服务交付。"
+                "md": "## 协创松 Buildathon 年度总决赛\n\n- 参赛人群：S1、S2、S3 联赛晋级团队（共60个团队），以及经官方评审具备同等产品能力的 AI+OPC 创业者，总共不超100个团队。\n- AI实战训练营：7月27日。\n- 协创松年度总决赛：7月28日至7月30日。\n- 颁奖活动 & 嘉年华：7月31日。\n- 比赛形式：线下72小时协创马拉松 Buildathon，集中冲刺产品迭代、部署上线或服务交付。"
         },
         "card-stage01-culture": {
                 "title": "企业出题 - 数字文化",
@@ -3316,6 +3315,19 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "数智OPC加速赛": "Digital OPC Accelerator",
         "跨境OPC加速赛": "Cross-Border OPC Accelerator",
         "全球青年培育赛": "Global Youth Incubator",
+        // 12 schedule card titles (per ops weekly template)
+        "【初赛W1】数智OPC加速赛": "Round 1 · W1 · Digital OPC Accelerator",
+        "【复赛W2】数智OPC加速赛": "Round 2 · W2 · Digital OPC Accelerator",
+        "【半决赛W3】数智OPC加速赛": "Semifinal · W3 · Digital OPC Accelerator",
+        "【决赛W4】数智OPC加速赛": "Final · W4 · Digital OPC Accelerator",
+        "【初赛W1】跨境OPC加速赛": "Round 1 · W1 · Cross-Border OPC Accelerator",
+        "【复赛W2】跨境OPC加速赛": "Round 2 · W2 · Cross-Border OPC Accelerator",
+        "【半决赛W3】跨境OPC加速赛": "Semifinal · W3 · Cross-Border OPC Accelerator",
+        "【决赛W4】跨境OPC加速赛": "Final · W4 · Cross-Border OPC Accelerator",
+        "【初赛W1】全球青年培育赛": "Round 1 · W1 · Global Youth Incubator",
+        "【复赛W2】全球青年培育赛": "Round 2 · W2 · Global Youth Incubator",
+        "【半决赛W3】全球青年培育赛": "Semifinal · W3 · Global Youth Incubator",
+        "【决赛W4】全球青年培育赛": "Final · W4 · Global Youth Incubator",
         // ---- Footer / general ----
         "免责申明": "Disclaimer",
         "查看免责申明": "View disclaimer",
@@ -3487,8 +3499,8 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "AI实战训练营（线上&线下）：7月27日": "AI Bootcamp (online & offline): Jul 27",
         "AI实战训练营（线上&amp;线下）：7月27日": "AI Bootcamp (online & offline): Jul 27",
         "协创松年度总决赛（线下）：7月28日至7月30日": "Annual Buildathon Final (offline): Jul 28 – Jul 30",
-        "颁奖典礼&嘉年华（线下）：7月31日": "Awards & Carnival (offline): Jul 31",
-        "颁奖典礼&amp;嘉年华（线下）：7月31日": "Awards & Carnival (offline): Jul 31",
+        "颁奖活动&嘉年华（线下）：7月31日": "Awards & Carnival (offline): Jul 31",
+        "颁奖活动&amp;嘉年华（线下）：7月31日": "Awards & Carnival (offline): Jul 31",
         // ---- Awards rows ----
         "一等奖1支团队/3万元": "1st Prize · 1 team · ¥30,000",
         "二等奖1支团队/1万元": "2nd Prize · 1 team · ¥10,000",


### PR DESCRIPTION
## Summary

Brings the landing page in sync with two long-pending content sources:

1. **Three text fixes from #112** that were bundled into the now-closed PR #113. PR #113 mixed these pure-text changes with the rejected DB-hydration logic, so they were lost on close. This PR cherry-picks them clean.
2. **12 schedule card titles** from @Cynthialime's [weekly-ops-template](https://github.com/user-attachments/files/27229187/weekly-ops-template.md) (the path-1 route confirmed in #114).

## Changes

### Org section (#112 fixes)

- Removed 5 unit-count badges:
  - `Directing Authorities · 7` → `Directing Authorities`
  - `Hosts · 3` → `Hosts`
  - `Organizers · 2` → `Organizers`
  - `Co-organizers · 7+` → `Co-organizers`
  - `Venture Capital · 4+` → `Venture Capital`
- Removed `上海市学生事务中心` chip + reference in rule popup co-organizer list
- Replaced all `颁奖典礼` → `颁奖活动` (4 occurrences, including 2 i18n DICT keys)

### Schedule section — 12 wave card titles

Format: `【{round-name}{wave-id}】{league-name}`

| Wave | Old | New |
|---|---|---|
| S1-W1 | `初赛/Wave 1` | `【初赛W1】数智OPC加速赛` |
| S1-W2 | `复赛/Wave 2` | `【复赛W2】数智OPC加速赛` |
| S1-W3 | `半决赛/Wave 3` | `【半决赛W3】数智OPC加速赛` |
| S1-W4 | `决赛/Wave 4` | `【决赛W4】数智OPC加速赛` |
| S2-W1..W4 | same pattern | `【...W#】跨境OPC加速赛` |
| S3-W1..W4 | same pattern | `【...W#】全球青年培育赛` |

### i18n DICT additions

12 new ZH→EN entries for the new card titles:
- e.g. `"【初赛W1】数智OPC加速赛": "Round 1 · W1 · Digital OPC Accelerator"`

## Out of scope

These items from the weekly template are **not** in this PR — they need ops to confirm slug naming first (see [#114 closing comment](https://github.com/HackForger/hackforger/issues/114) about the W1/W2 vs W3+ prefix mismatch):

- `HACKFORGER_LANDING_CONFIG.stages` slug bindings (still all `tbd`)
- Per-card time-tag updates (e.g., `#报名 4.29-5.5` → fresh dates)
- Per-card button copy state changes (active/disabled)

Those are weekly-cadence ops changes and will land in subsequent small PRs once @Cynthialime confirms the unified slug format.

## What stays unchanged

- The 4 overview cards near the top of the page (`task-wave-1` ... `task-wave-4`) keep their generic `初赛/Wave 1` titles. Those are league-agnostic explainers, not schedule cards.
- Rule popup wave names (inside the `rule-stage-01/02/03` markdown templates) keep their original format — they're already in a per-league context.

## Test plan

- [x] `grep` checks pass (count badges, 上海市学生事务中心, 颁奖典礼 all 0; 颁奖活动 ≥ 4; new card titles 24 = 12 HTML + 12 dict)
- [ ] Visual diff after rebuild: org section has no count badges; co-organizer chip list does not contain 上海市学生事务中心; 12 schedule cards show new titles
- [ ] Language toggle (ZH↔EN) shows English versions for new card titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)