### PR TITLE
feat(landing): permanent permalink /lingang-2026

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -11,6 +11,8 @@
 <meta property="og:title" content="第二届燕缘·协创者号 AI+ 国际创业大赛"/>
 <meta property="og:description" content="S1 即刻启动 · 数智 OPC 加速赛"/>
 <meta property="og:type" content="website"/>
+<meta property="og:url" content="/lingang-2026"/>
+<link rel="canonical" href="/lingang-2026"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&amp;family=Epilogue:wght@400;700;900&amp;family=Manrope:wght@400;700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -486,6 +486,11 @@ func registerRoutes(m *web.Route) {
 	// Especially some AJAX requests, we can reduce middleware number to improve performance.
 
 	m.Get("/", Home)
+	// HackForger: permanent permalink for the 2026 Lingang event landing.
+	// Reuses Home handler so anonymous visitors see the landing page; signed
+	// users still go to dashboard. Future events get their own /lingang-YYYY
+	// route while / always reflects the current default.
+	m.Get("/lingang-2026", Home)
 	m.Get("/sitemap.xml", sitemapEnabled, ignExploreSignIn, HomeSitemap)
 	m.Group("/.well-known", func() {
 		m.Get("/openid-configuration", auth.OIDCWellKnown)


### PR DESCRIPTION
## Summary

Adds **/lingang-2026** as a permanent permalink for the 2026 Lingang event landing page.

- New route registered in `routers/web/web.go` that reuses the existing `Home` handler
- Canonical link + `og:url` added to the landing HTML so search engines and social cards consolidate on the permanent URL

## Behavior

| URL | Anonymous visitor | Signed-in user |
|---|---|---|
| `/` | Landing (current event) | Dashboard |
| **`/lingang-2026`** | **Same landing** | Dashboard |

Both URLs serve the exact same content for anonymous visitors. The permalink lets the marketing/ops team share a stable URL that won't change when the next event launches.

## Future event scenario

When 2027 event ships:
1. Add `m.Get("/lingang-2027", Home)` (1 line)
2. Update `/`'s landing content (or repoint `Home` to render the new event)
3. `/lingang-2026` keeps serving the archived 2026 content

## Why reuse Home (instead of a dedicated handler)

Smallest possible change. Trade-off: signed-in users at `/lingang-2026` see the dashboard, not the landing. If ops feedback says signed users should also see the event landing at this URL, a dedicated handler can be split out later.

## Test plan

- [x] Build passes
- [ ] After merge + rebuild: `curl -I https://hackforger.inside.h2os.cloud/lingang-2026` returns 200
- [ ] Landing renders identically to `/`
- [ ] HTML head contains `<link rel="canonical" href="/lingang-2026">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)