### PR TITLE
feat(landing): rework schedule cards (tags + buttons + height) + 上海国投 chip split

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -1584,7 +1584,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <span class="px-2 py-0.5 bg-primary text-black text-[9px] font-black rounded-[2px] font-oppo">企业命题赛区</span>
 </div><p class="light-text-black text-on-surface-variant text-sm md:text-base lg:text-lg font-normal mb-8 leading-relaxed font-oppo max-w-xl md:max-w-none md:whitespace-nowrap">数字文化赛道、数字营销赛道、数字产业赛道、智能应用赛道、智能网联赛道、X创新赛道</p>
 </div>
-<div class="flex items-start gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
+<div class="flex items-stretch gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
 <div class="w-full overflow-hidden" style="aspect-ratio: 3 / 2;">
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S1-1.webp"/>
@@ -1592,11 +1592,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 4.29-5.5</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 5.6-5.7</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 5.8</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 5.9</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月6日-5月8日</span>
 </div>
 <button data-stage="s1-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">立即报名</button>
 </div>
@@ -1608,13 +1604,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.7-5.9</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 5.10-5.14</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 5.15</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 5.16</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月10日-5月15日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s1-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5.7-5.9报名</button>
+<button disabled aria-disabled="true" data-stage="s1-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月7日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1624,13 +1616,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.14-5.16</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 5.17-5.23</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 5.24</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 5.25</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月17日-5月24日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s1-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5.14-5.16报名</button>
+<button disabled aria-disabled="true" data-stage="s1-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月14日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1640,10 +1628,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】数智OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#决赛 6.17-6.18</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">6月17日-6月18日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s1-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6.17-6.18决赛</button>
+<button disabled aria-disabled="true" data-stage="s1-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6月17日-6月18日决赛</button>
 </div>
 </div>
 </div>
@@ -1661,7 +1648,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <span class="px-2 py-0.5 bg-primary text-black text-[9px] font-black rounded-[2px] font-oppo">企业命题赛区</span>
 </div>
 <p class="light-text-black text-on-surface-variant text-sm md:text-base lg:text-lg font-normal mb-8 leading-relaxed font-oppo max-w-xl lg:max-w-3xl">跨境数据服务、跨境文化服务、跨境电商服务、跨境IT服务</p>
-<div class="flex items-start gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
+<div class="flex items-stretch gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
 <div class="w-full overflow-hidden" style="aspect-ratio: 3 / 2;">
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S2-1.webp"/>
@@ -1669,13 +1656,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.11-5.26</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 5.27-5.28</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 5.29</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 5.30</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月27日-5月29日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s2-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5.11-5.26报名</button>
+<button disabled aria-disabled="true" data-stage="s2-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月11日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1685,13 +1668,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.28-5.30</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 5.31-6.4</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 6.5</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 6.6</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月31日-6月5日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s2-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5.28-5.30报名</button>
+<button disabled aria-disabled="true" data-stage="s2-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月28日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1701,13 +1680,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 6.4-6.6</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 6.7-6.13</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 6.14</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 6.15</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">6月7日-6月14日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s2-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6.4-6.6报名</button>
+<button disabled aria-disabled="true" data-stage="s2-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6月4日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1717,10 +1692,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】跨境OPC加速赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#决赛 6.17-6.18</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">6月17日-6月18日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s2-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6.17-6.18决赛</button>
+<button disabled aria-disabled="true" data-stage="s2-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">6月17日-6月18日决赛</button>
 </div>
 </div>
 </div>
@@ -1741,7 +1715,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <span class="px-2 py-0.5 bg-primary text-black text-[9px] font-black rounded-[2px] font-oppo">企业命题赛区</span>
 </div>
 <p class="light-text-black text-on-surface-variant text-sm md:text-base lg:text-lg font-normal mb-8 leading-relaxed font-oppo max-w-xl lg:max-w-3xl">数智场景各赛道、跨境服务各赛道，面向毕业五年内的全球青年创业者开放</p>
-<div class="flex items-start gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
+<div class="flex items-stretch gap-4 overflow-x-auto no-scrollbar pb-4 -mx-6 px-6">
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
 <div class="w-full overflow-hidden" style="aspect-ratio: 3 / 2;">
 <img loading="lazy" decoding="async" alt="Wave 1" class="w-full h-full object-cover" src="assets/images/S3-1.webp"/>
@@ -1749,13 +1723,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【初赛W1】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 5.11-6.24</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 6.25-7.1</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 7.2</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 7.3</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">6月25日-7月2日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s3-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5.11-6.24报名</button>
+<button disabled aria-disabled="true" data-stage="s3-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月11日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1765,13 +1735,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【复赛W2】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 7.1-7.3</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 7.4-7.10</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 7.11</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 7.12</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">7月4日-7月11日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s3-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">7.1-7.3报名</button>
+<button disabled aria-disabled="true" data-stage="s3-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">7月1日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1781,13 +1747,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【半决赛W3】全球青年培育赛</h5>
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#报名 7.10-7.12</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#开发 7.13-7.19</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#互评 7.20</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#公布晋级 7.21</span>
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">7月13日-7月20日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s3-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">7.10-7.12报名</button>
+<button disabled aria-disabled="true" data-stage="s3-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">7月10日开始报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1796,11 +1758,10 @@ window.HACKFORGER_LANDING_CONFIG = {
 </div>
 <div class="p-6 pt-5 flex flex-col flex-1">
 <h5 class="text-lg font-bold text-on-surface font-oppo mb-2">【决赛W4】全球青年培育赛</h5>
-<div class="mb-6 flex items-center gap-2">
-<span class="inline-flex items-center px-2 py-0.5 bg-[#41FAF4] text-black text-[8px] font-black rounded-[2px] font-oppo">官方命题</span>
-<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">#6月-7月</span>
+<div class="mb-6 flex items-center flex-wrap gap-1.5">
+<span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">7月28日-7月30日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s3-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">立即报名</button>
+<button disabled aria-disabled="true" data-stage="s3-w4" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">7月28日-7月30日决赛</button>
 </div>
 </div>
 </div>
@@ -1923,7 +1884,9 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="text-[10px] font-bold tracking-[0.2em] uppercase opacity-60 font-oppo mt-1">Venture Capital</div>
 </div>
 <div class="flex flex-wrap gap-2 md:gap-2.5">
-<span class="org-chip"><span class="org-chip-dot"></span>上海国投</span>
+<span class="org-chip"><span class="org-chip-dot"></span>上海国投科创</span>
+<span class="org-chip"><span class="org-chip-dot"></span>上海国投未来</span>
+<span class="org-chip"><span class="org-chip-dot"></span>上海国投赋能</span>
 <span class="org-chip"><span class="org-chip-dot"></span>临港集团</span>
 <span class="org-chip"><span class="org-chip-dot"></span>临港青年创业基金</span>
 <span class="org-chip"><span class="org-chip-dot"></span>燕缘创投</span>


### PR DESCRIPTION
## Summary

Completes the remaining items from #112 (Cynthialime's 2026-04-30 spec) plus a card-height fix mentioned by ops.

### What's in this PR

| Area | Change |
|---|---|
| **Card tags (12 cards)** | Replace 5 split tags (官方命题 + 4 phase dates) with 1 merged time tag |
| **Card buttons (11 cards)** | "X.X-X.X报名" → "X月X日开始报名" / W4 → "X月X日-X月X日决赛" |
| **Row height alignment (3 rows)** | `items-start` → `items-stretch` so all cards in a row match the tallest sibling |
| **创投支持 chip** | Split "上海国投" single chip into "上海国投科创" / "上海国投未来" / "上海国投赋能" three chips |

### Tag mapping (per Cynthialime's spec)

```
S1-W1: 5月6日-5月8日       (开发 5.6-5.7 + 互评 5.8)
S1-W2: 5月10日-5月15日     (开发 5.10-5.14 + 互评 5.15)
S1-W3: 5月17日-5月24日     (开发 5.17-5.23 + 互评 5.24)
S1-W4: 6月17日-6月18日     (决赛)
S2-W1: 5月27日-5月29日
S2-W2: 5月31日-6月5日
S2-W3: 6月7日-6月14日
S2-W4: 6月17日-6月18日
S3-W1: 6月25日-7月2日
S3-W2: 7月4日-7月11日
S3-W3: 7月13日-7月20日
S3-W4: 7月28日-7月30日
```

### Button mapping

| Card | New text | Reason |
|---|---|---|
| S1-W1 | `立即报名` (unchanged) | Today (2026-04-30) is within reg window 4.30-5.5 |
| S1-W2 | `5月7日开始报名` | Reg starts 5.7 |
| S1-W3 | `5月14日开始报名` | Reg starts 5.14 |
| S1-W4 | `6月17日-6月18日决赛` | Final |
| S2-W1 | `5月11日开始报名` | Reg starts 5.11 |
| S2-W2 | `5月28日开始报名` | Reg starts 5.28 |
| S2-W3 | `6月4日开始报名` | Reg starts 6.4 |
| S2-W4 | `6月17日-6月18日决赛` | Final |
| S3-W1 | `5月11日开始报名` | Reg starts 5.11 |
| S3-W2 | `7月1日开始报名` | Reg starts 7.1 |
| S3-W3 | `7月10日开始报名` | Reg starts 7.10 |
| S3-W4 | `7月28日-7月30日决赛` | Final (also fixed an anomaly where this disabled button used to show "立即报名") |

### Height fix detail

Each schedule row was `<div class="flex items-start gap-4 ...">`. With `items-start`, flex children only grow as tall as their content. W4 cards (only 2 tags) ended up visibly shorter than their W1-W3 siblings. Changed to `items-stretch` (flex's default) so cards in the same row equalize.

### Section banner tags kept

`#4月-5月` / `#5月-6月` / `#6月-7月` season banners under each league title (e.g. above "数智OPC加速赛") are league-level descriptors, not card-level tags. They're preserved per spec scope.

### Diff stat

- 1 file (custom/public/assets/landing/index.html)
- +30 / -67 (net 37 fewer lines because each card lost 4 tag spans)

## Test plan

- [x] Pre-rebuild grep checks (12 new tags, 11 new button texts, 3 items-stretch, 0 old splits, 3 上海国投 chips)
- [ ] Visual: Open https://hackforger.inside.h2os.cloud after deploy, verify all 12 schedule cards show only 1 time tag and align in height
- [ ] Visual: 创投支持 section shows 3 上海国投 chips
- [ ] Click each disabled button — none should error; modal should still appear for unbound slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)