### PR TITLE
feat(landing): wire 12 schedule cards to production slugs

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -714,18 +714,18 @@
 <script id="hackforger-landing-config">
 window.HACKFORGER_LANDING_CONFIG = {
   stages: {
-    's1-w1': { slug: 'tbd', enabled: true  },
-    's1-w2': { slug: 'tbd', enabled: false },
-    's1-w3': { slug: 'tbd', enabled: false },
-    's1-w4': { slug: 'tbd', enabled: false },
-    's2-w1': { slug: 'tbd', enabled: false },
-    's2-w2': { slug: 'tbd', enabled: false },
-    's2-w3': { slug: 'tbd', enabled: false },
-    's2-w4': { slug: 'tbd', enabled: false },
-    's3-w1': { slug: 'tbd', enabled: false },
-    's3-w2': { slug: 'tbd', enabled: false },
-    's3-w3': { slug: 'tbd', enabled: false },
-    's3-w4': { slug: 'tbd', enabled: false }
+    's1-w1': { slug: 'opc-2026-shuzhi-w1',      enabled: true  },
+    's1-w2': { slug: 'opc-2026-shuzhi-w2',      enabled: false },
+    's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: false },
+    's1-w4': { slug: 'opc-2026-shuzhi-w4',      enabled: false },
+    's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: false },
+    's2-w2': { slug: 'opc-2026-crossborder-w2', enabled: false },
+    's2-w3': { slug: 'opc-2026-crossborder-w3', enabled: false },
+    's2-w4': { slug: 'opc-2026-crossborder-w4', enabled: false },
+    's3-w1': { slug: 'opc-2026-youth-w1',       enabled: false },
+    's3-w2': { slug: 'opc-2026-youth-w2',       enabled: false },
+    's3-w3': { slug: 'opc-2026-youth-w3',       enabled: false },
+    's3-w4': { slug: 'opc-2026-youth-w4',       enabled: false }
   }
 };
 </script>


### PR DESCRIPTION
Closes #122. Wires HACKFORGER_LANDING_CONFIG.stages to production slug mapping per Cynthialime's #122 spec. Required after the prod-init data wipe + 12-hackathon seed so the landing page "立即报名" buttons route correctly. Today is 2026-04-30, so only S1-W1 (registration 4.30-5.5) is enabled; the other 11 disabled until their windows open.

Generated as part of the prod-init clean-slate migration.