### PR TITLE
fix(migrations): patch 3 PG-incompatible patterns + document freshDB skip

### DIFF
--- a/docs/notes/pg-migration-pitfalls.md
+++ b/docs/notes/pg-migration-pitfalls.md
@@ -129,6 +129,51 @@ HackForger 历来用 SQLite 开发 + 内部测试。首次迁到 PG 是 2026-04-
 
 ---
 
+## ⚠ 关键发现：fresh DB 上 migrations 的 Upgrade 函数**永不执行**
+
+排查 phase_type seed bug 时调研 Forgejo migration runner 源码（`models/forgejo_migrations/migrate.go:151-179`），发现一个根本性机制：
+
+```go
+if len(inDBMigrationIDs) == 0 && freshDB {
+    // During startup on a new, empty database, and during integration tests, we rely
+    // only on `SyncAllTables` to create the DB schema. No migrations can be applied
+    // because `SyncAllTables` occurs later in the initialization cycle. We mark all
+    // migrations as complete up to this point and only run future migrations.
+    for _, migration := range orderedMigrations {
+        err := recordMigrationComplete(x, migration)  // ← only records, no Upgrade()
+        ...
+    }
+}
+```
+
+### 这意味着
+
+**任何 migration 的 `Upgrade` 函数对 fresh DB（空 `forgejo_version` 表）都不执行。** 所有 v14a~v14k 的 Upgrade 在新 PG / 新 SQLite 实例启动时都被**跳过**，但 `forgejo_migration` 表里却被 mark 成 complete。Schema 由 `SyncAllTables` 单独创建（仅建表，不运行 Upgrade 里的 seed/data 操作）。
+
+### 影响
+
+任何依赖 migration `Upgrade` 函数做 **seed 数据 / 反查初始化** 的场景，**对 fresh DB 都失效**：
+
+- v14b 的 11 行 phase_type seed inserts → fresh DB 上不跑 → 表空
+- v14g 的 2 行 hackforger_setting seed inserts → fresh DB 上不跑 → 表空
+- v14j 的 `UPDATE phase_type SET is_unique = 0 ...` → fresh DB 上不跑（且就算跑也是 PG 类型错）
+
+### 为什么之前 SQLite 上有 seed？
+
+历史原因——HackForger 早期开发实例可能在 fresh-DB-skip 逻辑被引入 Forgejo 之前就跑过 migration（那时 Upgrade 函数是会执行的）。或者旧版 Forgejo 没有 freshDB 短路。一旦 seed 被插入，后续所有 sync 都保留它，所以从来没暴露过。
+
+### 这对源码 fix 的实际意义
+
+本文档下面列出的 fix（v14g backtick → builder.Eq 等）**只能影响"已经有部分 migration 历史的 DB 升级"路径**——即从某版已有 v14a..v14k 但缺 v14g 的 DB upgrade 上来。
+
+**对 fresh PG / fresh SQLite，源码 fix 无效。** 真正的 fix 路径只有两种：
+1. **手工 seed**（`RESTORE.md` 的 Post-migrate manual seed 节）—— 当前生产用的
+2. **加 post-`SyncAllTables` 初始化 hook**（Forgejo 上游层面的改动，工作量大；目前不做）
+
+源码 fix 的价值是 **代码质量 / 上游正确性 / 防止未来 freshDB 行为改变后再踩**，不是实际解决 fresh DB 的 seed 问题。
+
+---
+
 ## 相关
 
 - `RESTORE.md` 的「Post-migrate manual seed」节（`.claude/worktrees/dev/data-snapshot/RESTORE.md`）

--- a/models/forgejo_migrations/v14g_hackforger-phase2-tables.go
+++ b/models/forgejo_migrations/v14g_hackforger-phase2-tables.go
@@ -6,6 +6,7 @@ package forgejo_migrations
 import (
 	"forgejo.org/modules/timeutil"
 
+	"xorm.io/builder"
 	"xorm.io/xorm"
 )
 
@@ -68,7 +69,10 @@ func addHackforgerPhase2Tables(x *xorm.Engine) error {
 		{Key: "reputation.tiers", Value: `[{"name":"Bronze","min":0},{"name":"Silver","min":50},{"name":"Gold","min":200},{"name":"Diamond","min":500}]`},
 	}
 	for _, s := range defaults {
-		has, err := x.Where("`key` = ?", s.Key).Exist(new(v14gHackforgerSetting))
+		// PG-safe: avoid backtick identifier quoting (PG requires double-quotes for
+		// identifiers; backticks are a SQL syntax error). Use builder.Eq for dialect-
+		// agnostic identifier handling. See docs/notes/pg-migration-pitfalls.md.
+		has, err := x.Where(builder.Eq{"key": s.Key}).Exist(new(v14gHackforgerSetting))
 		if err != nil {
 			return err
 		}

--- a/models/forgejo_migrations/v14h_hackforger-judge-system.go
+++ b/models/forgejo_migrations/v14h_hackforger-judge-system.go
@@ -4,6 +4,8 @@
 package forgejo_migrations
 
 import (
+	"context"
+
 	"forgejo.org/modules/timeutil"
 
 	"xorm.io/xorm"
@@ -78,17 +80,16 @@ func addJudgeSystemTables(x *xorm.Engine) error {
 	if _, err := x.Exec("DROP INDEX IF EXISTS IDX_hackathon_submission_fork_repo_id"); err != nil {
 		return err
 	}
-	// Check if column exists before dropping (idempotent)
-	tableInfo, err := x.QueryString("PRAGMA table_info(hackathon_submission)")
+	// Check if column exists before dropping (idempotent).
+	// PG-safe: PRAGMA is SQLite-only and would syntax-error in PG. Use XORM's
+	// dialect-agnostic IsColumnExist instead. See docs/notes/pg-migration-pitfalls.md.
+	hasCol, err := x.Dialect().IsColumnExist(x.DB(), context.Background(), "hackathon_submission", "fork_repo_id")
 	if err != nil {
 		return err
 	}
-	for _, col := range tableInfo {
-		if col["name"] == "fork_repo_id" {
-			if _, err := x.Exec("ALTER TABLE hackathon_submission DROP COLUMN fork_repo_id"); err != nil {
-				return err
-			}
-			break
+	if hasCol {
+		if _, err := x.Exec("ALTER TABLE hackathon_submission DROP COLUMN fork_repo_id"); err != nil {
+			return err
 		}
 	}
 

--- a/models/forgejo_migrations/v14j_allow-multiple-judging-phases.go
+++ b/models/forgejo_migrations/v14j_allow-multiple-judging-phases.go
@@ -11,7 +11,10 @@ func init() {
 	registerMigration(&Migration{
 		Description: "Allow multiple judging phases (set is_unique=false for hackathon judging phase type)",
 		Upgrade: func(x *xorm.Engine) error {
-			_, err := x.Exec("UPDATE phase_type SET is_unique = 0 WHERE activity_kind = 'hackathon' AND key = 'judging'")
+			// PG-safe: is_unique is BOOLEAN in PG; integer literal 0 raises a type error.
+			// Use parameterized boolean (works in both PG and SQLite).
+			// See docs/notes/pg-migration-pitfalls.md.
+			_, err := x.Exec("UPDATE phase_type SET is_unique = ? WHERE activity_kind = ? AND key = ?", false, "hackathon", "judging")
 			return err
 		},
 	})


### PR DESCRIPTION
## Summary

Three small patches to existing HackForger migrations + a doc extension.

## Migration fixes

| File | Issue | Fix |
|---|---|---|
| `v14g_hackforger-phase2-tables.go:71` | Backtick-quoted identifier `\`key\` = ?` is SQL syntax error in PG | Use `builder.Eq{\"key\": k}` (dialect-agnostic) |
| `v14j_allow-multiple-judging-phases.go:14` | `is_unique = 0` is type error on PG BOOLEAN column | Parameterized `is_unique = ?` + Go bool `false` |
| `v14h_hackforger-judge-system.go:82` | `PRAGMA table_info(...)` is SQLite-only | `x.Dialect().IsColumnExist(...)` (cross-dialect) |

All three migrations build cleanly (`make backend` succeeds).

## Doc extension

Adds a critical-finding section to `docs/notes/pg-migration-pitfalls.md`:

**Forgejo migrations' Upgrade() functions never run on a fresh DB.**

The migration runner at `models/forgejo_migrations/migrate.go:163-178` mark-completes all migrations without calling Upgrade() when bootstrapping an empty database. Schema is created separately via `SyncAllTables`. Any seed/data initialization in Upgrade() is therefore lost.

**Implication for these fixes:** they serve only the upgrade path (an existing DB missing some specific migration). Fresh PG/SQLite databases will still have empty seed tables. The operational fix for fresh DBs is documented in `RESTORE.md` (in the `dev/test-data-backup-2026-04-30` branch under `.claude/worktrees/dev/data-snapshot/RESTORE.md`).

## Why fix at all if Upgrade() doesn't run on fresh DB?

- Code quality / open-source citizenship — wrong code in shipped migrations is misleading
- Defense in depth: if Forgejo's freshDB-skip behavior changes (or is removed), these migrations would suddenly be invoked on fresh DBs and would currently fail
- Reduces cognitive load when reading the codebase (no \"why is there a backtick here that obviously breaks PG?\" confusion)

## Out of scope

- Adding a post-`SyncAllTables` seed hook (proper fresh-DB fix) — separate larger effort
- Re-running v14j on existing PG DBs (handled manually during prod-init clean-slate)

Refs prod-init clean-slate (#125 docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)