### PR TITLE
fix(api): reject hackathon registration when user is a judge

### DIFF
--- a/routers/api/v1/hackforger/hackathon_registration.go
+++ b/routers/api/v1/hackforger/hackathon_registration.go
@@ -74,6 +74,16 @@ func Register(ctx *context.APIContext) {
 		ctx.Error(http.StatusBadRequest, "InvalidPhase", "hackathon is not accepting registrations")
 		return
 	}
+	// Judges cannot register as participants in their own hackathon (parity with web handler).
+	isJudge, err := hackforger_model.IsJudgeForAnyTrack(ctx, h.ID, ctx.Doer.ID)
+	if err != nil {
+		ctx.InternalServerError(err)
+		return
+	}
+	if isJudge {
+		ctx.Error(http.StatusForbidden, "JudgeCannotRegister", "judges cannot register as participants in their own hackathon")
+		return
+	}
 	f := web.GetForm(ctx).(*RegisterForm)
 	r := &hackforger_model.HackathonRegistration{
 		HackathonID: h.ID,


### PR DESCRIPTION
## Summary

Fixes a security/business-rule gap in the API: judges could bypass the web-handler's "judge cannot participate" check by registering directly via API.

## Discovery

Found during PG E2E user-journey-full-cycle (Step 2.6). The web handler at \`routers/web/hackforger/hackathon.go:345-353\` already rejects registration attempts by users who are judges (loops over \`ListJudges\` and checks \`UserID == ctx.Doer.ID\`). The API handler had no equivalent check.

Repro before fix:
\`\`\`bash
curl -X POST -H "Authorization: token \$JUDGE_TOKEN" \
  -d '{"team_name":"X","track_id":3}' \
  /api/v1/hackforger/hackathons/{id}/register
# → HTTP 201 (BUG: should be 403)
\`\`\`

After fix:
\`\`\`
HTTP 403 {"message":"judges cannot register as participants in their own hackathon"}
\`\`\`

## Implementation

Use existing \`hackforger_model.IsJudgeForAnyTrack(ctx, hackathonID, userID)\` (added by an earlier judging-system migration). Returns 403 with error code \`JudgeCannotRegister\` when the doer is registered as a judge for any track in this hackathon.

## Test plan

- [x] Carol (judge for track 3 of hackathon 6) → HTTP 403 with proper message
- [x] Eve (non-judge) → HTTP 201 (sanity, not affected by check)
- [ ] Web flow unchanged (existing check still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)