### PR TITLE
chore(scripts): add restart-gitea-test.sh + document test instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ All new code lives in `*/hackforger/` directories, minimizing changes to upstrea
 - `go test ./services/hackforger/... -v` -- Run service tests
 - `./gitea web` -- Start server (http://localhost:3000)
 - `bash scripts/restart-gitea.sh` -- **After merging a PR**: one-command atomic rebuild + restart of the main instance. Does: build → stop-if-binary-path-matches → start → verify HTTP 200. Refuses to kill port-3000 processes whose binary path isn't the main repo's `gitea`, so it's safe to automate.
+- `bash scripts/restart-gitea-test.sh` -- Same flow for the **test instance** (port 3001, `--custom-path /tmp/hackforger-test-custom`, log at `/tmp/gitea-test.log`). Use after editing test app.ini or rebuilding while it's up.
 - Restart server manually (fallback): kill old process, remove LevelDB lock (`rm -f data/queues/common/LOCK`), then start
 
 ## Important Constraints
@@ -91,14 +92,38 @@ All new code lives in `*/hackforger/` directories, minimizing changes to upstrea
 - `GITHUB_TOKEN` -- For gh CLI and GitHub API
 - `FORGEJO_TOKEN` -- For self-hosted HackForger instance API
 - `FORGEJO_URL` -- https://hackforger.inside.h2os.cloud
+- `HACKFORGER_ADMIN_PASSWORD` -- `hackforger` admin password on the **production** instance (port 3000)
+- `HACKFORGER_TEST_ADMIN_PASSWORD` -- `hackforger` admin password on the **test** instance (port 3001) — different from prod
+- `PGPASSWORD` -- Postgres password for the `hackforger` DB user (covers both `hackforger` and `hackforger_test` databases)
+- All of the above live in `.env` (gitignored). Source it with `set -a; . .env; set +a` if a tool needs them in the shell.
 
-## Internal Instance
-- Login: hackforger / admin1234
+## Internal Instance (Production)
+- URL: https://hackforger.inside.h2os.cloud (Caddy → localhost:3000)
+- Login: hackforger / `$HACKFORGER_ADMIN_PASSWORD`
+- DB: `hackforger` on Postgres
 - Caddy reverse proxy: managed by launchd (com.h2os.caddy), do NOT restart or unload
 - Check Caddy status: `launchctl list com.h2os.caddy`
 - Caddy config: ~/.config/caddy/ (Caddyfile, env, run.sh)
 - ⚠️ If Caddy config reload is needed, MUST confirm with developer first: `caddy reload --config ~/.config/caddy/Caddyfile`
 - Default branch: v0.1-dev/hackforger
+
+## Test Instance
+- URL: http://localhost:3001 (no Caddy, direct)
+- Custom path: `/tmp/hackforger-test-custom` (contains `conf/app.ini`)
+- Work path: `/tmp/hackforger-test-data`
+- DB: `hackforger_test` on Postgres (separate from prod's `hackforger`)
+- Login: hackforger / `$HACKFORGER_TEST_ADMIN_PASSWORD` (**different from prod**)
+- Restart: `bash scripts/restart-gitea-test.sh` (rebuild + safe restart)
+- Use for: E2E tests, schema/migration experiments, anything you don't want hitting prod data
+- ⚠️ Do NOT share `WORK_PATH` with the prod instance (LevelDB lock conflict)
+- ⚠️ Action runners are bound to one instance via `.runner` file — a runner registered against port 3000 will NOT pick up jobs dispatched on 3001. For test E2E that involves Actions, register a separate runner with its own config dir.
+
+## Action Runners (local dev machine)
+- **Production runner**: `~/.config/forgejo-runner/` — daemon under launchd `com.h2os.forgejo-runner`, auto-starts at login
+- **Test runner**: `~/.config/forgejo-runner-test/` — registered against port 3001 but NOT under launchd; start manually only when running E2E
+  - Start:  `cd ~/.config/forgejo-runner-test && nohup ~/.local/bin/forgejo-runner daemon > runner.log 2>&1 & disown`
+  - Stop:   `pkill -f 'forgejo-runner daemon$'` (matches the no-flag invocation; spares the prod daemon which uses `--config config.yml`)
+- Both runners use `host` mode labels (`ubuntu-latest:host`, `macos-arm64:host`) — jobs run directly on the mac, no Docker required. Beware: `runs-on: ubuntu-latest` in YAML actually runs against macOS BSD shell tools.
 
 ## Git Remotes
 - `origin` -- git@github.com:HackForger/hackforger.git (our repo)

--- a/scripts/restart-gitea-test.sh
+++ b/scripts/restart-gitea-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Restart the HackForger test gitea instance with the latest build.
+#
+# Mirror of restart-gitea.sh but targets the test instance:
+#   port:        3001
+#   custom path: /tmp/hackforger-test-custom
+#   work path:   /tmp/hackforger-test-data
+#   database:    hackforger_test (PG)
+#
+# Safe to automate: only kills processes whose binary path matches $BINARY.
+# Refuses to touch port 3001 if it's held by anything else.
+#
+# Usage:  bash scripts/restart-gitea-test.sh
+
+set -euo pipefail
+
+REPO="/Users/h2oslabs/Workspace/hackforger"
+BINARY="$REPO/gitea"
+CUSTOM_PATH="/tmp/hackforger-test-custom"
+WORK_PATH="/tmp/hackforger-test-data"
+PORT=3001
+LOG="/tmp/gitea-test.log"
+
+cd "$REPO"
+
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+echo "[2/4] Checking for process on port $PORT..."
+PID=$(lsof -iTCP:$PORT -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$PID" ]; then
+  RUNNING_BIN=$(lsof -p "$PID" 2>/dev/null | awk '/txt.*REG.*\/gitea$/{print $NF; exit}')
+  if [ "$RUNNING_BIN" = "$BINARY" ]; then
+    echo "    Stopping test instance (PID $PID, binary $RUNNING_BIN)"
+    kill "$PID"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      lsof -iTCP:$PORT -sTCP:LISTEN -t >/dev/null 2>&1 || break
+      sleep 1
+    done
+  else
+    echo "    Port $PORT is held by a different binary: $RUNNING_BIN" >&2
+    echo "    Expected: $BINARY" >&2
+    echo "    Not killing. Inspect with: lsof -p $PID" >&2
+    exit 1
+  fi
+else
+  echo "    Nothing on port $PORT."
+fi
+
+echo "[3/4] Starting new instance..."
+rm -f "$WORK_PATH/data/queues/common/LOCK"
+./gitea web --custom-path "$CUSTOM_PATH" > "$LOG" 2>&1 &
+disown
+NEW_PID=$!
+echo "    Started PID $NEW_PID, log at $LOG"
+
+echo "[4/4] Waiting for HTTP 200..."
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/ 2>/dev/null || echo "000")
+  if [ "$STATUS" = "200" ]; then
+    echo "    ✓ HTTP 200 on localhost:$PORT"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "    ⚠ Timed out waiting for HTTP 200 — check $LOG" >&2
+tail -20 "$LOG" >&2 || true
+exit 1


### PR DESCRIPTION
## Summary
- New script \`scripts/restart-gitea-test.sh\` mirrors the existing prod restart script but targets the test instance (port 3001, \`--custom-path /tmp/hackforger-test-custom\`, log at \`/tmp/gitea-test.log\`). Same safety guard: only kills processes whose binary path is the repo's \`gitea\`.
- CLAUDE.md gains three new pieces of documentation: a **Test Instance** section, an **Action Runners** section, and updated **Environment Variables** + **Internal Instance** entries that reference \`\$HACKFORGER_ADMIN_PASSWORD\` / \`\$HACKFORGER_TEST_ADMIN_PASSWORD\` instead of the obsolete \`admin1234\` literal.

## Why now
While verifying the hackathon submission-index Action workflow end-to-end, the prod runner was stuck on \`unauthenticated: unregistered runner\` (DB row had been wiped, local \`.runner\` file was stale) and the test instance had \`[actions] ENABLED = false\` plus an admin password not documented anywhere. Both are fixed now; this PR captures the conventions so the next person doesn't rediscover them.

## Test plan
- [x] \`bash scripts/restart-gitea-test.sh\` rebuilds + restarts the test instance and prints \`✓ HTTP 200 on localhost:3001\`
- [x] Script refuses to kill a port-3001 process whose binary isn't the repo \`gitea\` (untested directly but inherited from the prod script's logic)
- [x] CLAUDE.md renders cleanly; all new env-var names exist in \`.env\`
- [ ] Reviewer: confirm the env-var convention (\`HACKFORGER_TEST_ADMIN_PASSWORD\` for port 3001) matches your mental model

🤖 Generated with [Claude Code](https://claude.com/claude-code)