### PR TITLE
fix(hackathon): align submission-index workflow names + suppress mac keychain noise

### DIFF
--- a/docs/notes/forgejo-actions-yaml-drift.md
+++ b/docs/notes/forgejo-actions-yaml-drift.md
@@ -1,0 +1,116 @@
+# Embedded workflow YAML drifts after distribution
+
+A property of Forgejo Actions (and GitHub Actions) that bites you the
+first time. Not specific to HackForger, but worth knowing because we
+embed workflow YAML in Go code and write it into downstream repos at
+creation time.
+
+## The mechanism
+
+Forgejo Actions reads workflow definitions from each repo's own
+`.forgejo/workflows/*.yml` files. There is no central "template
+registry" that workflow runs consult — each repo owns its workflow as a
+plain committed file.
+
+If your service writes a workflow file into a downstream repo as a
+side-effect of some action (e.g. "create track repo" → installs an
+auto-index workflow), then from that moment on:
+
+- The Go source string and the file in the downstream repo are
+  **decoupled**.
+- Future dispatches against that repo execute the file the repo
+  carries, not the latest source.
+- Editing the Go source only affects repos created **after** the edit.
+
+## Concrete example (HackForger)
+
+`services/hackforger/hackathon.go` defines `submissionIndexWorkflow`
+as a Go const. `CreateTrackWithRepo` writes that string to
+`.forgejo/workflows/update-submission-index.yml` in every new track
+repo. Today (May 2026) only this one workflow is distributed this
+way.
+
+| Event | Effect on the YAML in downstream track repos |
+| --- | --- |
+| Edit the Go const, no rebuild | nothing happens — distributed copies unchanged |
+| Edit + rebuild + restart server | new tracks get new YAML; existing tracks keep old YAML |
+| Existing track dispatches a run after the change | runs against its **old** YAML |
+| Backfill script overwrites the file in each track repo | now in sync; next dispatch uses new YAML |
+
+## When this is harmless
+
+Cosmetic edits — step name, comments, log noise suppression. Old and
+new YAML produce equivalent observable behavior. Skip the backfill;
+let the old copies live out their lives.
+
+PR #132 (this one) is an example: rename a step, fix a docstring, add
+`credential.helper ""`. Nothing breaks for old tracks.
+
+## When this hurts
+
+Anything that changes **observable behavior or contracts**:
+
+- API path the workflow calls changed (`/api/v1/foo` → `/api/v1/bar`)
+- Input schema changed (renamed/added/removed `inputs.*`)
+- Bug in the workflow logic itself (jq expression, git command, etc.)
+- Required env var added
+
+In these cases, **existing track repos will keep failing or producing
+wrong output** until their YAML files are overwritten. The Go-side
+`triggerSubmissionIndexUpdate` may also need a feature flag if it
+dispatches with new inputs that old YAML doesn't understand.
+
+## How to backfill
+
+One-off Go script or admin endpoint:
+
+```go
+tracks, _ := hackforger_model.ListAllTracksWithRepo(ctx)
+for _, track := range tracks {
+    repo, _ := repo_model.GetRepositoryByID(ctx, track.RepoID)
+    _, _ = files_service.ChangeRepoFiles(ctx, repo, sysUser, &files_service.ChangeRepoFilesOptions{
+        OldBranch: repo.DefaultBranch,
+        NewBranch: repo.DefaultBranch,
+        Message:   "Sync update-submission-index.yml to latest template",
+        Files: []*files_service.ChangeRepoFile{{
+            Operation:     "update",
+            TreePath:      ".forgejo/workflows/update-submission-index.yml",
+            ContentReader: strings.NewReader(submissionIndexWorkflow),
+        }},
+    })
+}
+```
+
+Each track repo gets one new commit on its default branch.
+
+## Avoiding the problem long-term
+
+If a workflow is going to evolve frequently, switch from embedded YAML
+to a **reusable workflow** kept in a central repo. Each track repo
+then carries only a one-line stub:
+
+```yaml
+# .forgejo/workflows/update-submission-index.yml
+on: workflow_dispatch
+jobs:
+  call:
+    uses: hackforger-ops/workflows/.forgejo/workflows/update-index.yml@v1
+    with: { hackathon_id: '${{ inputs.hackathon_id }}', ... }
+```
+
+Updating the central workflow auto-applies to all consumers (subject
+to the `@v1` pin — bump the tag for breaking changes).
+
+Trade-off: introduces a hard dependency on the central repo being
+reachable, plus the auth/permission story for cross-repo `uses:`.
+Worth it only if you actually expect frequent edits.
+
+## Lesson summary
+
+- Inline embedded YAML = "ship and forget". Cheap, but distributed
+  copies drift forever.
+- Reusable workflow = central control. More moving parts, but edits
+  propagate.
+- For HackForger today (one workflow, low edit frequency), inline is
+  the right call. Re-evaluate if `submissionIndexWorkflow` starts
+  changing more than once per quarter.

--- a/services/hackforger/hackathon.go
+++ b/services/hackforger/hackathon.go
@@ -189,6 +189,11 @@ jobs:
     steps:
       - name: Checkout repo
         run: |
+          # Disable any system credential helper (e.g. macOS osxkeychain on
+          # host-mode runners) — it can't store creds in a non-interactive
+          # session and emits a noisy "failed to store: -25308" line. The
+          # token is embedded in the push URL below, so no helper is needed.
+          git config --global credential.helper ""
           git clone "${{ github.server_url }}/${{ github.repository }}.git" repo
           cd repo
           git config user.name "${{ github.actor }}"
@@ -220,7 +225,7 @@ jobs:
 
           echo "$TRACK_SUBS" | jq '[.[] | {id: .ID, title: .Title, description: .Description, user_id: .UserID, repo_id: .RepoID, demo_url: .DemoURL}]' > submissions.json
 
-      - name: Commit, push, create PR, and auto-merge
+      - name: Commit and push to main
         working-directory: repo
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -688,7 +693,9 @@ func DeleteSubmission(ctx context.Context, doer *user_model.User, submissionID i
 // triggerSubmissionIndexUpdate dispatches the update-submission-index workflow
 // in the track repo via the Forgejo Actions internal API. The workflow handles
 // fetching submissions, regenerating SUBMISSIONS.md + submissions.json, and
-// creating a PR -- all within the Actions runner, not in Go code.
+// pushing the update directly to main -- all within the Actions runner, not
+// in Go code. Existing track repos still carry the old workflow YAML; the new
+// version only ships with tracks created after this change.
 func triggerSubmissionIndexUpdate(ctx context.Context, doer *user_model.User, h *hackforger_model.Hackathon, track *hackforger_model.HackathonTrack) {
 	if track.RepoID == 0 {
 		return

--- a/services/hackforger/hackathon.go
+++ b/services/hackforger/hackathon.go
@@ -162,6 +162,12 @@ func CreateHackathon(ctx context.Context, doer *user_model.User, h *hackforger_m
 // submissionIndexWorkflow is the Forgejo Actions workflow committed into every
 // track repo. It is dispatched via workflow_dispatch whenever a new submission
 // is created, and regenerates SUBMISSIONS.md + submissions.json from the API.
+//
+// IMPORTANT: editing this string only affects tracks created AFTER the edit.
+// Existing tracks keep the YAML they were initialised with, because the file
+// lives in their git history. Read docs/notes/forgejo-actions-yaml-drift.md
+// before making behavior-changing edits — it covers when a backfill is
+// required and how to write one.
 const submissionIndexWorkflow = `name: Update Submission Index
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Three small, related cleanups to the embedded \`update-submission-index\` workflow in \`services/hackforger/hackathon.go\`, all surfaced during the first end-to-end verification of the Action runner pipeline against the test instance:

- **Step rename**: \`Commit, push, create PR, and auto-merge\` → \`Commit and push to main\`. The implementation already pushes directly to main (see the inline comment on lines 237–238); the step name was a leftover from an earlier design.
- **Function docstring**: \`triggerSubmissionIndexUpdate\`'s comment said the workflow "creates a PR". Updated to describe the actual push-to-main behavior, plus a note that **existing track repos carry the old YAML** and only tracks created after this PR will get the new copy.
- **Suppress osxkeychain noise**: macOS host-mode runners log \`failed to store: -25308\` on every push (osxkeychain failing in a non-interactive session). The URL-embedded token is what actually authenticates, so we disable the helper. No-op on Linux.

No behavior change for new tracks beyond cleaner logs and accurate identifiers.

## Backfill
Existing track repos in production already have the old workflow YAML committed at \`.forgejo/workflows/update-submission-index.yml\`. Their behavior is unchanged. If we want to retrofit existing tracks, that's a separate one-off operation (loop over tracks → \`ChangeRepoFiles\` to overwrite the YAML).

## Test plan
- [x] \`go build ./services/hackforger/...\` clean
- [x] Diff is YAML-string + comment changes only; no logic changes
- [ ] On merge: any new track created via \`CreateTrackWithRepo\` will get the updated YAML — sanity-check by inspecting \`.forgejo/workflows/update-submission-index.yml\` in the next track repo

## Discovered alongside
PR #131 (test-instance restart script + docs) was opened from the same E2E session; this PR is the matching code-side cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)