### PR TITLE
fix(attachment): allow public read for HackForger RepoID=-1 attachments

### DIFF
--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -106,7 +106,12 @@ func ServeAttachment(ctx *context.Context, uuid string) {
 	}
 
 	if repository == nil { // If not linked
-		if !ctx.IsSigned || attach.UploaderID != ctx.Doer.ID { // We block if not the uploader
+		// HackForger platform-level attachments (RepoID=-1) are intended to be embedded
+		// in public hackathon descriptions, grant project pages, and submissions.
+		// They must be readable by anonymous viewers, not just the original uploader.
+		if attach.RepoID == -1 {
+			// Allow public access — these are platform/HackForger-managed assets.
+		} else if !ctx.IsSigned || attach.UploaderID != ctx.Doer.ID { // We block if not the uploader
 			ctx.Error(http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
## Bug

HackForger uploads files via POST /hackforger/attachments with RepoID=-1 (platform-level). These are meant to be embedded in PUBLIC hackathon descriptions, grant pages, etc.

`ServeAttachment` (routers/web/repo/attachment.go) blocks anonymous viewers from RepoID=-1 attachments — only the uploader can read. Symptom: image embedded in hackathon detail page returns 404 for public visitors.

## Fix

Special-case `attach.RepoID == -1` to allow public read; other unlinked attachments still require uploader auth (unchanged behavior for non-HackForger uploads).

## Discovery

Found while building cover-image markdown for the 4 prod S1 hackathons (opc-2026-shuzhi-w1..w4). The uploaded UUID URL `/attachments/{uuid}` returned 404 even with admin token.

## Test plan

- [x] Build clean
- [ ] After merge + restart: `curl /attachments/{uuid}` (uploaded via /hackforger/attachments) returns 200 for anonymous

🤖 Generated with [Claude Code](https://claude.com/claude-code)