### PR TITLE
fix(landing): default theme to dark for first-time visitors

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -2086,9 +2086,9 @@ window.HACKFORGER_LANDING_CONFIG = {
         try {
             var raw = localStorage.getItem(THEME_KEY);
             if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
-            return 'system';
+            return 'dark';
         } catch (e) {
-            return 'system';
+            return 'dark';
         }
     }
 


### PR DESCRIPTION
## Summary

`readThemeMode()` previously returned `'system'` when localStorage was empty, which then resolves to whatever the visitor's OS prefers. Visitors on light-OS therefore saw the landing in light theme on first visit.

Default to `'dark'` so first impression matches HackForger brand.

## Diff

```diff
function readThemeMode() {
    try {
        var raw = localStorage.getItem(THEME_KEY);
        if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
-        return 'system';
+        return 'dark';
    } catch (e) {
-        return 'system';
+        return 'dark';
    }
}
```

## What's preserved

- Users who explicitly chose `'light'` or `'dark'` or `'system'` keep their choice (stored values still match the `if`)
- Only the **fallback** for fresh visitors changes

## Test plan

- [x] Verified prod renders updated function on `/` and `/lingang-2026`
- [ ] Visual check on prod (clear localStorage → reload → should be dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)