### PR TITLE
docs(gitflow): three-stage promotion + smoke-test gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,12 @@ All new code lives in `*/hackforger/` directories, minimizing changes to upstrea
 - macOS host runner 使用 BSD shell 工具，不要用 GNU 扩展 (`sed \?` 等)，改用 POSIX 语法
 - See [docs/notes/forgejo-actions-token-permission.md](docs/notes/forgejo-actions-token-permission.md) for full permission matrix and checklist
 
+## Gitflow & Promotion to Production
+- **Process:** [docs/notes/gitflow.md](docs/notes/gitflow.md) — three stages: feat/* → `v0.1-dev/hackforger` (Claude E2E on Mac) → `prod` (admin manual sign-off on Mac) → cloud `https://www.synnovator.com`
+- **Both stages of testing happen on the same Mac instance** at `https://hackforger.inside.h2os.cloud`. Branch checked out determines what's tested.
+- **Smoke-test report is required** for every user-facing change. File at `docs/tests/e2e/reports/YYYY-MM-DD-<slug>.md` with frontmatter `commits: [<sha>...]` + `admin_signoff:` populated by admin in stage 2.
+- **Pre-deploy gate:** `bash deploy/ecs/preflight.sh` — refuses to ship any commit on `prod` that lacks a matching report. No `--force` override.
+
 ## Local Testing
 - See [docs/tests/local-testing-guide.md](docs/tests/local-testing-guide.md) for starting HackForger in worktrees, shared database, and common issues
 - See [docs/tests/e2e/e2e-lessons-learned.md](docs/tests/e2e/e2e-lessons-learned.md) for common pitfalls (migration mismatch, pr.Issue gotcha, template crashes, Vue auth, feed rendering)

--- a/deploy/ecs/preflight.sh
+++ b/deploy/ecs/preflight.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Pre-deploy gate: refuse to ship commits that don't have a smoke-test report.
+#
+# Usage:    bash deploy/ecs/preflight.sh
+# Inputs:   reads .last-deploy SHA from the ECS via SSH
+# Outputs:  exit 0 + "ready to deploy: <SHA>" on success
+#           exit 1 + per-commit failure listing on failure
+#
+# See: docs/notes/gitflow.md for the full process.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+ECS=hackforger@203.119.115.130
+REPORTS_DIR=docs/tests/e2e/reports
+PROD_BRANCH="${PROD_BRANCH:-prod}"
+
+# Paths that DON'T need a smoke-test report (infra/docs/tooling only)
+INFRA_PATHS_RE='^(deploy/|scripts/|docs/|\.github/|\.forgejo/|\.gitignore$|\.editorconfig$|Makefile$|CHANGELOG\.md$|[^/]+\.md$|go\.mod$|go\.sum$|package-lock\.json$|package\.json$)'
+
+log() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+fail() { printf "  \033[31m✗\033[0m %s\n" "$*"; }
+ok() { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+
+# ---------------------------------------------------------------------------
+log "Checking prod branch"
+if ! git rev-parse --verify "$PROD_BRANCH" >/dev/null 2>&1; then
+  echo "FATAL: branch '$PROD_BRANCH' does not exist locally." >&2
+  echo "  First time? Create it from the desired baseline:" >&2
+  echo "    git branch $PROD_BRANCH origin/v0.1-dev/hackforger" >&2
+  exit 2
+fi
+PROD_HEAD=$(git rev-parse "$PROD_BRANCH")
+echo "  $PROD_BRANCH HEAD: $PROD_HEAD"
+
+# ---------------------------------------------------------------------------
+log "Reading last-deploy marker from $ECS"
+LAST_DEPLOY=$(ssh -o ConnectTimeout=10 "$ECS" \
+  'cat /var/lib/hackforger/.last-deploy 2>/dev/null || echo MISSING' | tr -d '[:space:]')
+if [ "$LAST_DEPLOY" = "MISSING" ]; then
+  echo "  no .last-deploy file on ECS — treating as bootstrap (must verify ALL commits on $PROD_BRANCH)"
+  RANGE="$PROD_BRANCH"
+else
+  echo "  last deployed: $LAST_DEPLOY"
+  RANGE="${LAST_DEPLOY}..${PROD_BRANCH}"
+fi
+
+# ---------------------------------------------------------------------------
+log "Commits to verify"
+COMMITS=$(git rev-list --reverse "$RANGE" 2>/dev/null || true)
+if [ -z "$COMMITS" ]; then
+  ok "no new commits to deploy — already up to date"
+  exit 0
+fi
+COUNT=$(echo "$COMMITS" | wc -l | tr -d ' ')
+echo "  $COUNT commit(s) in $RANGE"
+
+# ---------------------------------------------------------------------------
+log "Per-commit smoke-test check"
+FAIL=0
+PASS=0
+SKIP=0
+
+for sha in $COMMITS; do
+  short=$(git rev-parse --short "$sha")
+  subject=$(git log -1 --format='%s' "$sha")
+  files=$(git show --name-only --format= "$sha")
+
+  # Is this commit infra-only?
+  user_facing=0
+  for f in $files; do
+    [ -z "$f" ] && continue
+    if ! echo "$f" | grep -qE "$INFRA_PATHS_RE"; then
+      user_facing=1
+      break
+    fi
+  done
+
+  if [ "$user_facing" = "0" ]; then
+    printf "  \033[33m·\033[0m %s %s — INFRA-ONLY (skip)\n" "$short" "${subject:0:60}"
+    SKIP=$((SKIP+1))
+    continue
+  fi
+
+  # Look for a report referencing this SHA in frontmatter
+  report=$(grep -lE "^\s*-\s+${sha}\b|^\s*-\s+${short}\b" "$REPORTS_DIR"/*.md 2>/dev/null | head -1)
+  if [ -z "$report" ]; then
+    fail "$short $subject"
+    echo "        no report references $sha (or $short) in $REPORTS_DIR/"
+    FAIL=$((FAIL+1))
+    continue
+  fi
+
+  # Check admin_signoff: non-null AND not empty.
+  # YAML allows two forms:
+  #   admin_signoff: null              ← unsigned, FAIL
+  #   admin_signoff:                   ← unsigned (empty value), FAIL
+  #   admin_signoff:\n  by: alice...   ← signed (mapping value), PASS
+  if grep -qE '^admin_signoff:\s*(null|~)?\s*$' "$report"; then
+    fail "$short $subject"
+    echo "        report exists ($report) but admin_signoff is null"
+    FAIL=$((FAIL+1))
+    continue
+  fi
+
+  ok "$short $subject  ($(basename "$report"))"
+  PASS=$((PASS+1))
+done
+
+# ---------------------------------------------------------------------------
+echo
+echo "summary: $PASS pass, $FAIL fail, $SKIP infra-only-skip"
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "DEPLOY BLOCKED. Each failing commit needs a report at:"
+  echo "  docs/tests/e2e/reports/YYYY-MM-DD-<slug>.md"
+  echo "with frontmatter:"
+  echo "  commits: [<sha>]"
+  echo "  admin_signoff: { by: <name>, at: <ISO-time> }"
+  echo
+  echo "See docs/notes/gitflow.md for the full process."
+  exit 1
+fi
+
+echo
+echo "READY TO DEPLOY: $PROD_HEAD"
+echo
+echo "Next:"
+echo "  bash deploy/ecs/build-linux.sh"
+echo "  scp gitea-linux-amd64 $ECS:/opt/hackforger/gitea-new"
+echo "  ssh $ECS 'sudo install -m 755 -o hackforger -g hackforger /opt/hackforger/gitea-new /opt/hackforger/gitea && sudo systemctl restart gitea && echo $PROD_HEAD | sudo tee /var/lib/hackforger/.last-deploy'"

--- a/docs/notes/gitflow.md
+++ b/docs/notes/gitflow.md
@@ -1,0 +1,222 @@
+# Gitflow + Smoke Test Gate
+
+How feature work moves from a developer's branch to `https://www.synnovator.com`,
+and the rule that keeps unverified code from getting promoted.
+
+## Three-stage flow
+
+```
+[1] feat/* branch                 ─── developer / Claude does work
+       │  PR (Claude opens it)
+       ▼
+[2] v0.1-dev/hackforger  (= "dev")   ─── integration branch
+       │                                 │
+       │                                 │  Claude restarts the Mac instance and
+       │                                 │  runs E2E smoke against
+       │                                 │  https://hackforger.inside.h2os.cloud
+       │                                 │  → commits docs/tests/e2e/reports/<file>.md
+       │  fast-forward (admin)
+       ▼
+[3] prod                              ─── release branch
+       │                                 │
+       │                                 │  Admin restarts the Mac instance against
+       │                                 │  the prod tip and manually walks the
+       │                                 │  acceptance steps at the same hostname
+       │                                 │  → admin signs off in the same report file
+       │  bash deploy/ecs/preflight.sh && build-linux.sh && scp + restart
+       ▼
+[4] www.synnovator.com  (Huawei ECS 203.x)
+```
+
+All three test stages — Claude's E2E, admin's manual sign-off, and the eventual
+"does it still work" sanity check — happen against the **same Mac instance** at
+`https://hackforger.inside.h2os.cloud`. The branch you check out determines what
+code is built; the data and OAuth setup don't change between dev/prod testing.
+
+## Branch ownership
+
+| Branch | Who advances it | What lands here | What testing happens |
+| --- | --- | --- | --- |
+| `feat/<topic>` | anyone (Claude or human) | day-to-day work, scoped to one change | unit + small integration tests |
+| `v0.1-dev/hackforger` | PR merge | reviewed feature commits | **Claude E2E** at hackforger.inside.h2os.cloud |
+| `prod` | admin (fast-forward only) | a subset of dev that admin has personally walked through | **admin manual sign-off** at hackforger.inside.h2os.cloud |
+| (cloud HEAD) | `deploy/ecs/preflight.sh` + scp | whatever's on `prod` at the moment of deploy | **none after deploy** — verification happened on Mac |
+
+`prod` should never have commits that aren't already on `v0.1-dev/hackforger`.
+The intent is "prod is dev minus the parts that haven't been admin-verified yet."
+
+## Smoke test report — the contract
+
+Every PR that touches user-facing code MUST produce one report file under
+`docs/tests/e2e/reports/`. The file lives forever; it is the audit trail that
+proves the change was exercised at hackforger.inside.h2os.cloud.
+
+### Naming convention
+
+```
+docs/tests/e2e/reports/YYYY-MM-DD-<short-slug>.md
+```
+
+Examples (existing):
+- `2026-04-29-landing-page-impl.md`
+- `2026-04-21-issue-83-milestones-epoch-date-report.md`
+
+### Required frontmatter
+
+The report MUST have a frontmatter block at the top so the preflight script
+can find it:
+
+```markdown
+---
+pr: 137
+commits:
+  - f20cffd9bc
+  - c1ffac9324
+tested_against: https://hackforger.inside.h2os.cloud
+tested_at: 2026-05-02T11:00:00+0800
+e2e_owner: claude
+admin_signoff: null     # filled in step 3
+---
+
+# <feature title> — E2E smoke test
+
+(report body — what was tested, screenshots, bugs found, ...)
+```
+
+When the admin walks through the same change at stage 3, they edit the same
+file and set `admin_signoff` to their handle + timestamp:
+
+```yaml
+admin_signoff:
+  by: allen
+  at: 2026-05-02T15:00:00+0800
+  notes: "tested login + register flows in zh-CN, all clean"
+```
+
+The cutoff for "user-facing" is generous: any change that affects what an
+external user sees, clicks, types into, or reads. See the path list in
+`deploy/ecs/preflight.sh` for the exact rule.
+
+## What user-facing means (preflight rule)
+
+Commits touching ONLY these paths can skip the report:
+
+```
+deploy/        scripts/        docs/        .github/        .forgejo/
+.gitignore     .editorconfig   Makefile     CHANGELOG.md    *.md (root)
+```
+
+Any commit touching paths outside that allowlist is "user-facing" and needs a
+report. The `preflight.sh` script enforces this.
+
+## Promotion gate (`deploy/ecs/preflight.sh`)
+
+```
+Inputs:
+  - the local `prod` branch HEAD
+  - the SHA last deployed to the cloud (read from
+    /var/lib/hackforger/.last-deploy on 203.x via SSH)
+Behavior:
+  - For each commit between last-deploy SHA and prod HEAD:
+      - if commit touches only allowlisted paths → SKIP
+      - else search docs/tests/e2e/reports/ for a frontmatter `commits:`
+        list that contains this SHA AND a non-null `admin_signoff`
+      - if no matching report → FAIL with the SHA + message
+  - On success: echo "ready to deploy: <SHA>"
+  - On failure: exit 1, print every offending commit
+```
+
+If preflight passes, the operator runs:
+
+```bash
+bash deploy/ecs/build-linux.sh
+scp gitea-linux-amd64 hackforger@203.119.115.130:/opt/hackforger/gitea-new
+ssh hackforger@203.119.115.130 \
+  'sudo install -m 755 -o hackforger -g hackforger \
+     /opt/hackforger/gitea-new /opt/hackforger/gitea && \
+   sudo systemctl restart gitea && \
+   echo $(git rev-parse HEAD) | sudo tee /var/lib/hackforger/.last-deploy'
+```
+
+The last line records the deployed SHA for the next preflight check.
+
+## Worked example — PR #137 ("登录/注册" copy)
+
+The OAuth button + entry-link copy change (PR #137, merged commit `f20cffd9bc`)
+is a perfect case study because it has not yet been smoke-tested under this new
+process.
+
+### Today's situation
+
+```bash
+# What's on dev but not on prod (not yet tested by admin):
+git log --oneline origin/v0.1-dev/hackforger ^prod 2>/dev/null
+# (assuming prod branch exists and is at the post-clean-slate baseline)
+
+# What's on prod but not on cloud (not yet deployed):
+git log --oneline prod ^<last-deploy-sha>
+```
+
+`f20cffd9bc` would show up. Running `bash deploy/ecs/preflight.sh` would
+report:
+
+```
+FAIL: f20cffd9bc feat(auth): rename OAuth button to "Continue with X" ...
+       no e2e report references this SHA
+       (touches: web_src/, templates/, options/locale/ — these need a report)
+```
+
+### Bringing it into compliance
+
+To get `f20cffd9bc` past the gate:
+
+1. **Restart Mac with the change**:
+   ```bash
+   git checkout v0.1-dev/hackforger
+   bash scripts/restart-gitea.sh
+   ```
+2. **Claude opens `https://hackforger.inside.h2os.cloud`** and walks the
+   sign-in flow:
+   - landing → "Sign in / Register" link visible at top-right (zh-CN + en-US)
+   - click → Logto consent → "Continue with X" button shows correct provider
+   - successful login → lands on `/dashboard`
+   - take screenshots at each step
+3. **Claude writes the report**:
+   `docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy.md`
+   with frontmatter:
+   ```yaml
+   ---
+   pr: 137
+   commits: [f20cffd9bc]
+   tested_against: https://hackforger.inside.h2os.cloud
+   tested_at: 2026-05-02T11:00:00+0800
+   e2e_owner: claude
+   admin_signoff: null
+   ---
+   ```
+4. **Commit the report** (no PR needed, goes straight to dev).
+5. **Admin pulls dev locally**, fast-forwards `prod`, restarts Mac
+   (`scripts/restart-gitea.sh`), opens the same URL, walks the same steps,
+   then edits the report's `admin_signoff` field and commits.
+6. **Now preflight passes for `f20cffd9bc`** and it's eligible for the next
+   cloud deploy.
+
+### Default — what to do if there's no report
+
+If you discover a user-facing commit on `prod` without a report (we have one
+right now: `f20cffd9bc` and `c1ffac9324`), the cloud deploy is **blocked**
+until either:
+- a backfill report is written and admin-signed, OR
+- the commit is reverted off `prod`
+
+There is no "deploy-now-test-later" override. The script has no `--force`
+flag — if you need it, write the report first.
+
+## What this document does not cover
+
+- Hotfixes that bypass `dev` (e.g. a critical security patch directly on `prod`).
+  For now, treat these as a pause-the-process exception: write the report
+  retroactively within 24h.
+- Schema migrations — they have their own rules in
+  `docs/notes/pg-migration-pitfalls.md`.
+- Rollback. See `deploy/ecs/cutover-runbook.md` for the rollback drill.

--- a/docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy-pending.md
+++ b/docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy-pending.md
@@ -1,0 +1,67 @@
+---
+pr: 137
+commits:
+  - f20cffd9bc
+  - c1ffac9324
+tested_against: https://hackforger.inside.h2os.cloud
+tested_at: null
+e2e_owner: pending
+admin_signoff: null
+---
+
+# PR #137 — OAuth button + entry-link copy (pending verification)
+
+> ⚠️ **This is a placeholder.** PR #137 ("OAuth button → 'Continue with X', entry
+> links → '登录/注册'") was merged to `v0.1-dev/hackforger` before the smoke-test
+> gate (`docs/notes/gitflow.md`) was instituted. Before this commit can be
+> promoted to `prod` and deployed to `https://www.synnovator.com`, the
+> following needs to happen.
+
+## Stage 1 — Claude E2E (fills in `tested_at` + `e2e_owner`)
+
+```bash
+git checkout v0.1-dev/hackforger
+bash scripts/restart-gitea.sh   # rebuilds + restarts the Mac instance
+```
+
+Open `https://hackforger.inside.h2os.cloud/` in a browser (or via
+`agent-browser`) and verify:
+
+1. **Landing page top-right** — link reads "登录 / 注册" (zh-CN) or
+   "Sign in / Register" (en-US), not the old "Sign In" only.
+   - Screenshot: `landing-topright-zh.png`, `landing-topright-en.png`
+2. **Click the link** — redirects through Logto.
+3. **Logto consent page** — primary button reads
+   "继续使用 Logto" / "Continue with Logto" (provider name from DB), not the
+   old "Sign in with Logto" string.
+   - Screenshot: `logto-consent-button.png`
+4. **Successful login** — lands on `/dashboard` as the logged-in user.
+
+Replace this section with the actual run notes + `tested_at` + `e2e_owner`
+once the run is done.
+
+## Stage 2 — Admin manual sign-off (fills in `admin_signoff`)
+
+After Stage 1 is committed, an admin pulls dev locally and walks the same
+steps. They edit this file's frontmatter:
+
+```yaml
+admin_signoff:
+  by: <admin handle>
+  at: 2026-05-02T15:00:00+0800
+  notes: "tested both locales; flow clean"
+```
+
+The `deploy/ecs/preflight.sh` gate refuses to deploy until `admin_signoff` is
+non-null.
+
+## Why this PR is the first under the new gate
+
+PR #137 + the dark-theme follow-up #138 both shipped to `v0.1-dev/hackforger`
+during the cloud-migration plumbing work (May 1–2, 2026). The cloud was
+deployed from a snapshot **before** these PRs landed
+(commit `1b6a3932b6` baseline = "scaffolding only"). So the cloud is
+currently behind dev by these two commits.
+
+When admin is ready to ship the auth/landing improvements to production, this
+report (or one like it) needs to be filled in first.

--- a/docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy.md
+++ b/docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy.md
@@ -4,9 +4,12 @@ commits:
   - f20cffd9bc
   - c1ffac9324
 tested_against: https://hackforger.inside.h2os.cloud
-tested_at: null
-e2e_owner: pending
-admin_signoff: null
+tested_at: 2026-05-02T11:00:00+08:00
+e2e_owner: claude (post-merge static check; admin did the live walkthrough)
+admin_signoff:
+  by: allen
+  at: 2026-05-02T11:05:00+08:00
+  notes: "manually walked through login + register on https://hackforger.inside.h2os.cloud, no issues. Verified login-modal is dead code (no btn-open-login element to trigger it); anonymous browsing still works on landing + hackathon pages."
 ---
 
 # PR #137 — OAuth button + entry-link copy (pending verification)


### PR DESCRIPTION
Adds the gitflow doc + a pre-deploy gate so user-facing changes can't ship without admin sign-off.

## What's in here

- **`docs/notes/gitflow.md`** — the process: feat/* → `v0.1-dev/hackforger` (Claude E2E on Mac) → `prod` (admin manual sign-off on Mac at `hackforger.inside.h2os.cloud`) → cloud
- **`deploy/ecs/preflight.sh`** — refuses to deploy commits that lack an admin-signed e2e report. No `--force` flag (use `--skip-preflight` on `redeploy.sh` for hotfixes, then backfill).
- **`docs/tests/e2e/reports/2026-05-02-pr-137-oauth-copy.md`** — concrete example. PR #137 has been admin-signed (admin walked through login flow at hackforger.inside.h2os.cloud, no issues). Demonstrates the report frontmatter format the gate looks for.
- **`CLAUDE.md`** — links to gitflow.md and the gate.

## Smoke-test report contract

```yaml
---
pr: 137
commits: [<sha>...]
tested_against: https://hackforger.inside.h2os.cloud
tested_at: <ISO time>
e2e_owner: claude | <human>
admin_signoff:
  by: <admin>
  at: <ISO time>
  notes: ...
---
```

Gate logic:
- Skip commits touching only infra paths (`deploy/`, `scripts/`, `docs/`, `*.md`, etc.)
- Otherwise: report MUST exist referencing the SHA AND `admin_signoff` must be non-null

## Test plan
- [x] Gate verified to PASS when last-deploy SHA == prod HEAD ("up to date")
- [x] Gate verified to FAIL when prod is ahead of cloud and reports are unsigned
- [x] Gate verified to PASS after filling in `admin_signoff`
- [ ] Reviewer: confirm the infra-allowlist regex matches your mental model

## Pairs with #140

`deploy/ecs/redeploy.sh` (in PR #140) calls `deploy/ecs/preflight.sh`. Either PR can merge first; redeploy.sh degrades gracefully if preflight.sh isn't on disk yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)