### PR TITLE
feat(hooks): protect archive branches + worktrees

### DIFF
--- a/.claude/hookify.protect-archive-branches.local.md
+++ b/.claude/hookify.protect-archive-branches.local.md
@@ -1,0 +1,33 @@
+---
+name: protect-archive-branches
+enabled: true
+event: bash
+action: block
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: git\s+(rebase|branch\s+-D|branch\s+--delete\s+(-f|--force)|push\s+(.*\s+)?(-f|--force)|reset\s+--hard).*\b(dev/[\w.-]*(backup|snapshot)[\w.-]*|test-data-backup-2026-04-30)\b
+  - field: command
+    operator: not_contains
+    pattern: CONFIRM_DESTROY=1
+---
+
+🛑 **Refusing to run destructive git op on a protected archive branch.**
+
+The branch you targeted matches the archive pattern (`dev/*-backup-*`, `dev/*-snapshot-*`, or `test-data-backup-2026-04-30`). These branches are intentional historical snapshots — rebasing, force-pushing, or hard-resetting them destroys irrecoverable state.
+
+**Before overriding, run the 3-question check** (from `~/.claude/projects/-Users-h2oslabs-Workspace-hackforger/memory/feedback_branch_rebase_check.md`):
+
+1. Is the branch pushed to origin? (if not, no one else has a copy)
+2. Is the branch / its files referenced by paths on the default branch? (e.g. `git grep <branch-or-path> v0.1-dev/hackforger`)
+3. Are the unique commits "snapshot" / "backup" / "preserve" themed?
+
+If any answer is YES → leave it alone, do not destroy.
+
+If you've checked all three and the user has explicitly confirmed they want to destroy this branch (rare):
+
+```bash
+CONFIRM_DESTROY=1 <your original command>
+```
+
+The `CONFIRM_DESTROY=1` env-var prefix is the explicit override; this hook will not block it.

--- a/.claude/hookify.protect-worktrees.local.md
+++ b/.claude/hookify.protect-worktrees.local.md
@@ -1,0 +1,32 @@
+---
+name: protect-worktrees
+enabled: true
+event: bash
+action: block
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: git\s+worktree\s+remove\s+(.*\s+)?\.claude/worktrees/
+  - field: command
+    operator: not_contains
+    pattern: CONFIRM_DESTROY=1
+---
+
+🛑 **Refusing to remove a worktree under `.claude/worktrees/`.**
+
+The worktrees in `.claude/worktrees/` are load-bearing:
+
+- **`.claude/worktrees/dev/`** — backs the `dev/test-data-backup-2026-04-30` archive branch. The default branch's `docs/notes/pg-migration-pitfalls.md` references files at `.claude/worktrees/dev/data-snapshot/RESTORE.md`. Removing the worktree breaks that reference.
+- Other worktrees may back active dev branches you didn't realize were in use.
+
+**Before overriding**, verify:
+
+1. The worktree's branch isn't referenced from the default branch (`git grep <worktree-path> v0.1-dev/hackforger`)
+2. No file in the worktree is unique (compare against the branch HEAD)
+3. The user has explicitly asked to remove it (not just "clean up")
+
+If all three pass, override with:
+
+```bash
+CONFIRM_DESTROY=1 git worktree remove .claude/worktrees/<name>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,9 @@ claude.local.sh
 /.env
 /.env.local
 docs/tests/e2e/*.pdf
-.claude/ralph-loop.local.md
+.claude/*.local.md
+# Project-wide guard-rail hooks ARE committed (override the .local.md ignore)
+!.claude/hookify.protect-*.local.md
 
 # E2E test screenshots (temporary artifacts, hosted on GitHub Releases if needed)
 tests/screenshots/


### PR DESCRIPTION
Two hookify rules + a feedback memory to prevent accidental destruction of historical/archive branches.

## What

- **`hookify.protect-archive-branches`** — blocks \`git rebase / branch -D / push --force / reset --hard\` whose target name matches \`dev/*-backup-*\`, \`dev/*-snapshot-*\`, or the existing \`test-data-backup-2026-04-30\` branch.
- **`hookify.protect-worktrees`** — blocks \`git worktree remove .claude/worktrees/<name>\` (those worktree paths are referenced from the default branch).
- Both support an explicit \`CONFIRM_DESTROY=1\` env-var prefix override for the rare case the operator really wants to destroy.

## Why

Past Claude sessions had been suggesting "rebase that stale-looking branch" without checking whether it's a load-bearing archive. This time around I almost rebased \`dev/test-data-backup-2026-04-30\` (which is referenced from the default branch's \`docs/notes/pg-migration-pitfalls.md\`). User pushed back; we wrote a memory rule (\`feedback_branch_rebase_check.md\`) about the 3-question check; user then asked for the tool-layer guard so we don't rely on memory.

These rules ARE committed (not just \`.local\` per-developer) because they protect project-wide invariants — anyone on the team or any future Claude session benefits. \`.gitignore\` gets a narrow exception for the \`hookify.protect-*\` family.

## Test plan
- [x] Created the rule files; hookify picked them up immediately
- [x] Trigger verified: a test command containing the protected branch name was blocked by the hook (caught my own diagnostic \`echo\`)
- [x] Override verified: prepending \`CONFIRM_DESTROY=1\` makes \`not_contains\` skip the rule (regex tested separately)
- [x] Benign commands (\`git status\`, \`git rebase v0.1-dev/hackforger\`, \`git push origin v0.1-dev/hackforger\`) do NOT match — pattern is properly scoped to the archive branch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)