### PR TITLE
chore(issues): add bug + feature templates with required fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,118 @@
+name: 🐛 Bug 报告 / Bug Report
+description: 报告 HackForger 上发现的功能问题（用户能看到/操作的）
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 谢谢你提交问题！请尽量按下面的字段填完，**信息越完整、修起来越快**。每个字段的提示都给了一句"该写什么"。
+        >
+        > 如果你不确定某些字段，留空也行，但是 **复现步骤 / 实际现象 / 期望现象** 这三项必填。
+
+  - type: input
+    id: page_url
+    attributes:
+      label: 出问题的页面 URL
+      description: 完整地址。如果是登录后才能看到的页面，**也直接贴 URL**，我们能猜到要登录哪个账户。
+      placeholder: "https://www.synnovator.com/hackathon/opc-2026-xxxxx"
+    validations:
+      required: true
+
+  - type: input
+    id: account
+    attributes:
+      label: 你用什么账号操作的？
+      description: 用户名（不要填密码）。如果是匿名访问，写 `匿名`。
+      placeholder: "linyilun"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤（一步一行）
+      description: |
+        从打开浏览器开始一步一步写。最理想是别人按你这个步骤一定能看到同样的现象。
+      placeholder: |
+        1. 用 linyilun 账号登录
+        2. 打开 https://www.synnovator.com/hackathon/opc-2026-shuzhi-w1
+        3. 点页面右下角"报名"区
+        4. 在"选择仓库"下拉框里找 H2OSLabs/page.h2oslabs.com
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望看到 / 期望发生的事
+      description: 一两句话即可。
+      placeholder: 下拉里应该列出我所属的 H2OSLabs 组织的所有可写仓库，包括 page.h2oslabs.com
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际看到 / 实际发生的事
+      description: 一两句话即可。如果有错误提示，原文贴出来。
+      placeholder: 下拉是空的，只有"— 选择仓库 —"占位符，找不到任何组织的仓库
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 截图
+      description: |
+        **强烈建议**贴 1-3 张截图（直接拖图到这个框里就会自动上传）。一张图胜过一千字。
+        如果是涉及多步操作的 bug，请截图关键步骤；如果有错误弹窗 / 红字提示，必须截图。
+      placeholder: 直接拖拽图片到这里
+    validations:
+      required: false
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: 出现频率
+      options:
+        - "每次都能复现"
+        - "偶尔出现（>50%）"
+        - "很少出现（<50%）"
+        - "只出现过一次"
+        - "不确定"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: 你在哪个环境测的？
+      options:
+        - "线上 https://www.synnovator.com"
+        - "内网 https://hackforger.inside.h2os.cloud"
+        - "本地开发实例"
+        - "其他（请在描述里说明）"
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: 浏览器 + 版本（可选）
+      description: 如果你不知道版本号，写浏览器名就行，比如 "Chrome" / "Safari" / "微信内置"。
+      placeholder: "Chrome 130 / Safari 17 / 微信内置"
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 其他补充（可选）
+      description: 比如"以前能用，今天突然不行"、"换个账号就好了"、"前几天 #134 改了相关功能可能有影响"等线索都欢迎写在这里。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,0 +1,49 @@
+name: ✨ 功能需求 / Feature Request
+description: 想要 HackForger 增加新功能、改进现有功能
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 提需求前先想想：是 **现有功能不好用**（→ 用 Bug 模板更合适），还是 **完全新功能**（→ 用这个模板）？
+        > 如果是想让 HackForger 多支持一种使用场景，欢迎在下面描述清楚。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 你现在遇到了什么问题？
+      description: |
+        先描述场景和痛点，**不要先描述方案**。
+        例如："我想把同一份代码同时报名两个 hackathon，现在做不到要分别建 fork。"
+      placeholder: 我想 ...，但是现在 ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 你希望怎么做？
+      description: 你的方案设想。如果不确定怎么实现，可以写多个候选思路。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 你试过的临时绕过方案
+      description: 如果有的话写一下，能帮我们判断这个需求的优先级。
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 这个需求对你有多紧急？
+      options:
+        - "马上就要 — 阻塞了我现在的工作"
+        - "近期需要 — 大约一两周内"
+        - "希望有 — 不急"
+        - "只是建议 — 觉得这样会更好"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 想先讨论一下？
+    url: https://github.com/HackForger/hackforger/discussions
+    about: 不确定是 bug 还是需求？想先聊聊？欢迎到 Discussions。
+  - name: 🚨 安全漏洞
+    url: mailto:security@h2os.cloud
+    about: 安全问题请直接邮件联系，不要在公开 issue 里发。


### PR DESCRIPTION
Triggered by #145, which was a one-line problem statement that took ~30 minutes of back-and-forth to extract usable detail (which hackathon, which user, which repo, screenshot of the dropdown).

The new bug template (`.github/ISSUE_TEMPLATE/1-bug.yml`) requires up front:
- 出问题的页面 URL
- 测试账号（不含密码）
- 复现步骤（多行）
- 期望 vs 实际
- 出现频率
- 环境（线上 / 内网 / 本地）

The new feature template (`2-feature.yml`) splits problem from proposal so we don't get "do X please" without knowing what X is supposed to solve.

`config.yml` disables blank-issue creation — every new issue must use one of the two templates (or hit the "want to discuss first?" Discussions link).

Templates are written in Chinese (testers' working language) with bilingual labels so English-speaking maintainers still scan at a glance. Existing `.forgejo/issue_template/*` (upstream Forgejo templates aimed at backend devs) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)