### PR TITLE
fix(navbar): hide hackathon/grant create entries for non-admins (#118 followup)

### DIFF
--- a/custom/templates/base/head_navbar.tmpl
+++ b/custom/templates/base/head_navbar.tmpl
@@ -171,6 +171,7 @@
 								</a>
 							</li>
 						{{end}}
+						{{if .SignedUser.IsAdmin}}
 							<li>
 								<a href="{{AppSubUrl}}/hackathons/new">
 									{{svg "octicon-rocket"}} {{ctx.Locale.Tr "hackforger.hackathon.new"}}
@@ -181,6 +182,7 @@
 									{{svg "octicon-heart"}} {{ctx.Locale.Tr "hackforger.grant.round.new"}}
 								</a>
 							</li>
+						{{end}}
 					</ul>
 				</div>
 			</details>


### PR DESCRIPTION
PR #136 (closes #118) added \`{{if .SignedUser.IsAdmin}}\` around the 创建黑客松 / 新建资助 entries in \`templates/base/head_navbar.tmpl\` — but \`custom/templates/base/head_navbar.tmpl\` (which Forgejo prefers when present) never got the same guard.

Effect: non-admin users still **saw** the entries in their nav dropdown. Clicking them hit the server-side guard and redirected to login (so security was intact), but the UX was inconsistent with the issue's "hide the entries" goal.

## Repro
1. Login as a non-admin user (e.g. linyilun)
2. Click the "+" dropdown in the navbar
3. **Before**: 创建黑客松 / 新建资助 visible; click → 303 redirect to /user/login
4. **After**: entries not rendered at all

## What changed
\`custom/templates/base/head_navbar.tmpl\` — added the same \`{{if .SignedUser.IsAdmin}}\` wrapper that upstream has. 2-line diff.

## Test plan
- [x] Restart Mac dev with patched custom template; verify dropdown DOM does not contain \`hackathons/new\` or \`grants/new\` for non-admin
- [x] Server-side route protection unchanged (route still 303s non-admins)
- [ ] Reviewer: confirm by logging in as any non-admin user

## Why was it missed in PR #136?
PR #136 patched the upstream \`templates/base/\` file. Forgejo's runtime prefers \`custom/templates/\` overrides when present. Some PRs since then (notably #137 OAuth copy work) updated the custom override but didn't carry over PR #136's guard. This is the exact "embedded YAML drift" failure mode but in the template-override layer instead of the workflow-YAML layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)