### PR TITLE
fix(hackforger): render org_join_request feed entry + 3 missing i18n keys

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -252,6 +252,8 @@ func NewFuncMap() template.FuncMap {
 				return "octicon-gift"
 			case opType >= 54 && opType <= 57:
 				return "octicon-heart"
+			case opType == 60:
+				return "octicon-organization"
 			default:
 				return "octicon-pulse"
 			}

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -4326,7 +4326,9 @@ grant.project.already_submitted = You have already submitted a project to this g
 ; Grant (template and flash message keys)
 grant.status = Status
 grant.budget = Budget
+grant.budget_credits = Credits Budget
 grant.currency = Currency
+grant.org_id_personal_hint = 0 = personal
 grant.used = Used
 grant.projects = Projects
 grant.view_projects = View Projects
@@ -4552,6 +4554,7 @@ feed.grant_round_cancelled = cancelled grant <a href="%[2]s">%[1]s</a>
 feed.credits_redeemed = redeemed credits
 feed.order_fulfilled = fulfilled order for %s
 feed.order_cancelled = cancelled order for %s
+feed.org_join_request = joined organization <a href="%[2]s">%[1]s</a>
 
 ; Dashboard community sidebar
 feed.sidebar.my_hackathons = Hackathons

--- a/options/locale/locale_zh-CN.ini
+++ b/options/locale/locale_zh-CN.ini
@@ -4398,7 +4398,9 @@ grant.project.already_submitted = 您已向该资助提交过项目。
 ; Grant (template and flash message keys)
 grant.status = 状态
 grant.budget = 预算
+grant.budget_credits = 积分预算
 grant.currency = 货币
+grant.org_id_personal_hint = 0 表示个人
 grant.used = 已使用
 grant.projects = 项目
 grant.view_projects = 查看项目
@@ -4624,6 +4626,7 @@ feed.grant_round_cancelled = 取消了资助 <a href="%[2]s">%[1]s</a>
 feed.credits_redeemed = 兑换了积分
 feed.order_fulfilled = 完成了「%s」的兑换订单
 feed.order_cancelled = 取消了「%s」的兑换订单
+feed.org_join_request = 加入了组织 <a href="%[2]s">%[1]s</a>
 
 ; Dashboard community sidebar
 feed.sidebar.my_hackathons = 黑客松

--- a/templates/hackforger/feed/community_feeds.tmpl
+++ b/templates/hackforger/feed/community_feeds.tmpl
@@ -33,6 +33,7 @@
 				{{else if eq .OpType 57}}{{ctx.Locale.Tr "hackforger.feed.grant_round_cancelled" .EntityName (HackforgerEntityURL .EntityType .EntitySlug)}}
 				{{else if eq .OpType 58}}{{ctx.Locale.Tr "hackforger.feed.order_fulfilled" .EntityName}}
 				{{else if eq .OpType 59}}{{ctx.Locale.Tr "hackforger.feed.order_cancelled" .EntityName}}
+				{{else if eq .OpType 60}}{{ctx.Locale.Tr "hackforger.feed.org_join_request" .EntityName (printf "%s/%s" AppSubUrl (.EntityName | PathEscape))}}
 				{{end}}
 				{{DateUtils.TimeSince .CreatedUnix}}
 			</div>

--- a/templates/hackforger/grants/new.tmpl
+++ b/templates/hackforger/grants/new.tmpl
@@ -49,7 +49,7 @@
 			</div>
 			<div class="field">
 				<label>{{ctx.Locale.Tr "hackforger.grant.org_id"}}</label>
-				<input type="number" name="org_id" min="0" value="0" placeholder="0 = personal">
+				<input type="number" name="org_id" min="0" value="0" placeholder="{{ctx.Locale.TrString "hackforger.grant.org_id_personal_hint"}}">
 			</div>
 			<div class="field">
 				<button class="hf-btn hf-btn-primary">{{ctx.Locale.Tr "hackforger.grant.round.create"}}</button>


### PR DESCRIPTION
## Summary

Two small but visible bugs the user spotted on `hackforger.inside.h2os.cloud`:

### Bug 1 — feed card with empty content

`templates/hackforger/feed/community_feeds.tmpl` covered OpType 30–43 and 50–59 but had **no branch for OpType 60** (`ActionOrgJoinRequest`). When `AddOrgUser` runs during hackathon registration (so the registrant gets added to the linked org), it emits an OpType=60 action; the feed then rendered as `[avatar]  haiquan      3 小时前   [·]` with no description text and a fallback `octicon-pulse` — which the user read as "logo and content missing."

- Add `{{else if eq .OpType 60}}` branch to render `joined organization <a>...</a>`
- Add `feed.org_join_request` key in both `locale_en-US.ini` and `locale_zh-CN.ini`
- Add `octicon-organization` icon mapping in `HackforgerActionIcon` for OpType 60

### Bug 2 — i18n holes on `/grants/new`

- `grants/new.tmpl:42` referenced `hackforger.grant.budget_credits` but the locale only defined `hackforger.grant.round.budget_credits` (extra `.round.` segment). Forgejo returns the key name as the value when the lookup misses, so the "Credits Budget" label showed as `hackforger.grant.budget_credits` literal text.
- `grants/new.tmpl:52` had a hardcoded `placeholder="0 = personal"` (English only) for the `org_id` input.

Fix: add `grant.budget_credits` and `grant.org_id_personal_hint` keys in both locale files; route the placeholder through `ctx.Locale.TrString`.

## Files changed

- `templates/hackforger/feed/community_feeds.tmpl` (+1 line)
- `templates/hackforger/grants/new.tmpl` (placeholder → i18n)
- `modules/templates/helper.go` (HackforgerActionIcon: add OpType 60 case)
- `options/locale/locale_en-US.ini` (+3 keys)
- `options/locale/locale_zh-CN.ini` (+3 keys)

Total: 5 files, 10 insertions, 1 deletion.

## Test plan

- [x] `TAGS="bindata sqlite sqlite_unlock_notify" make backend` clean
- [ ] After merge + restart: visit dashboard `/?repo-search-tab=hackathons` as a non-admin who has registered for a hackathon — the previously-empty card should show `加入了组织 <orgname>` with an organization icon
- [ ] Visit `/grants/new` (admin) — "积分预算" label renders correctly (no key string visible) and the org_id placeholder shows `0 表示个人` (zh) or `0 = personal` (en)
- [ ] No regression in other feed cards (OpType 30–59 still render as before)

## Related

- Companion to PR #149 (org-repo registration). That PR adds API parity for `AddOrgUser`, which means more OpType=60 events will be generated going forward — making this rendering fix more important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)