### PR TITLE
docs(skill): decouple hackforger-api skill from a single instance URL

### DIFF
--- a/skills/hackforger-api/INSTALL.md
+++ b/skills/hackforger-api/INSTALL.md
@@ -28,11 +28,15 @@ The agent fetches the GitHub URL, reads SKILL.md + references/ contents, and pla
 
 ## After install
 
-Set these env vars in your shell:
+Set these env vars in your shell. **Do not assume a default URL** —
+HackForger is deployed at many domains for different purposes, so the skill
+will ask you which instance to target if `FORGEJO_URL` is unset:
 
 ```bash
 export FORGEJO_TOKEN=<personal-access-token>
-export FORGEJO_URL=https://hackforger.inside.h2os.cloud   # or your instance URL
+# Pick the instance that matches your deployment, e.g.:
+export FORGEJO_URL=https://www.synnovator.com   # public production (example)
+# or http://localhost:3000 for local dev, or your own self-hosted URL
 ```
 
 Generate a token at `<FORGEJO_URL>/-/user/settings/applications`. Scope must

--- a/skills/hackforger-api/SKILL.md
+++ b/skills/hackforger-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hackforger-api
-description: Call HackForger platform API endpoints (hackathons, bounties, grants, credits, submissions, judging, feed, search, reputation, orgs, attachments). Use whenever the user asks to query or manage HackForger platform resources via natural language. Auth via FORGEJO_TOKEN env var, base URL via FORGEJO_URL (defaults to https://hackforger.inside.h2os.cloud).
+description: Call HackForger platform API endpoints (hackathons, bounties, grants, credits, submissions, judging, feed, search, reputation, orgs, attachments). Use whenever the user asks to query or manage HackForger platform resources via natural language. Auth via FORGEJO_TOKEN env var, base URL via FORGEJO_URL — there is no default, ask the user which instance to target if FORGEJO_URL is not set.
 ---
 
 # HackForger API skill
@@ -9,13 +9,33 @@ This skill lets you call any HackForger platform API endpoint via curl.
 Design principle: **every web user action has an API equivalent** — if a user
 can do it in the browser, you can do it through this skill.
 
+## Step 0 — Confirm the instance URL (do this first, every time)
+
+HackForger is deployed at multiple domains for different purposes (public
+production, private internal, staging, self-hosted by other teams). **The skill
+intentionally does not hard-code or default to any specific instance.** Before
+making any API call:
+
+1. Check whether `$FORGEJO_URL` is already set in the environment. If it is,
+   echo it back to the user once for confirmation ("I'll target
+   `$FORGEJO_URL` — confirm or override?") before proceeding.
+2. If `$FORGEJO_URL` is **not** set, ask the user which HackForger instance
+   they want to target. Examples you can offer to help them answer:
+   - `https://www.synnovator.com` (public production)
+   - `http://localhost:3000` (local dev)
+   - or their own deployment URL
+3. Export `FORGEJO_URL` for the session before issuing any curl call.
+
+Never silently fall back to a default URL — a wrong-instance call can mutate
+the wrong database.
+
 ## Authentication
 
-Set these env vars before invoking any endpoint:
+Once the instance URL is confirmed, set the token:
 
 ```bash
 export FORGEJO_TOKEN=<personal-access-token>      # required
-export FORGEJO_URL=https://hackforger.inside.h2os.cloud  # default; override for other instances
+export FORGEJO_URL=<the URL the user just confirmed in Step 0>
 ```
 
 Generate a token at `<FORGEJO_URL>/-/user/settings/applications`. Scope must
@@ -29,7 +49,7 @@ curl -s -X $METHOD \
   -H "Authorization: token $FORGEJO_TOKEN" \
   -H "Content-Type: application/json" \
   ${BODY:+-d "$BODY"} \
-  "${FORGEJO_URL:-https://hackforger.inside.h2os.cloud}/api/v1$PATH" | jq .
+  "${FORGEJO_URL:?set FORGEJO_URL first — see Step 0}/api/v1$PATH" | jq .
 ```
 
 Examples:
@@ -74,10 +94,11 @@ you don't miss a required step.
    exercise the actual web flow. API calls are appropriate for setup/teardown
    and feature-level integration tests, not for E2E.
 
-4. **Live instance has real data** — the production-like instance at
-   `hackforger.inside.h2os.cloud` shares its DB with daily use. Don't assume
-   Forgejo test fixtures (`user2`, `repo1`, `user5`) exist. Query
-   `GET /repos/search` or `GET /users/search` to find real targets.
+4. **Live instances have real data** — any production or production-like
+   HackForger instance shares its DB with daily use. Don't assume Forgejo test
+   fixtures (`user2`, `repo1`, `user5`) exist on the instance the user picked
+   in Step 0. Query `GET /repos/search` or `GET /users/search` to find real
+   targets before mutating anything.
 
 ## When the user asks to do something
 

--- a/skills/hackforger-api/references/attachments.md
+++ b/skills/hackforger-api/references/attachments.md
@@ -14,7 +14,7 @@ Forgejo's standard attachment endpoints (`/repos/{owner}/{repo}/issues/{index}/a
 curl -X POST \
   -H "Authorization: token $FORGEJO_TOKEN" \
   -F "file=@design.png" \
-  https://hackforger.inside.h2os.cloud/api/v1/hackforger/attachments
+  "${FORGEJO_URL:?set FORGEJO_URL first — see SKILL.md Step 0}/api/v1/hackforger/attachments"
 # → {"uuid":"a3f8...e2c1"}
 ```
 

--- a/skills/hackforger-api/references/orgs.md
+++ b/skills/hackforger-api/references/orgs.md
@@ -20,7 +20,7 @@ To **accept** or **reject** a join request, use Forgejo's standard team membersh
 ```bash
 curl -X POST \
   -H "Authorization: token $FORGEJO_TOKEN" \
-  https://hackforger.inside.h2os.cloud/api/v1/hackforger/orgs/web3-innovation/join-request
+  "${FORGEJO_URL:?set FORGEJO_URL first — see SKILL.md Step 0}/api/v1/hackforger/orgs/web3-innovation/join-request"
 # → 202 {"status":"notified"}
 ```
 


### PR DESCRIPTION
## Summary
- The `hackforger-api` skill no longer hard-codes / defaults to the internal `hackforger.inside.h2os.cloud` hostname in its description, env-var examples, or curl `:-` fallback.
- New **Step 0** in `SKILL.md` requires the agent to confirm `$FORGEJO_URL` with the user (or echo the existing env value back for confirmation) before any API call. HackForger is deployed at multiple domains for different purposes — silently picking one is a footgun.
- Curl template now uses `${FORGEJO_URL:?...}` so an unset URL fails loudly instead of silently routing to a default.
- Reference examples (`attachments.md`, `orgs.md`) and `INSTALL.md` use `${FORGEJO_URL}` / `https://www.synnovator.com` (public production) as the example, not the internal hostname.

## Test plan
- [ ] Re-install the skill in a fresh agent session (using the install prompt) and confirm the skill prompts for `$FORGEJO_URL` instead of defaulting.
- [ ] Confirm `curl "${FORGEJO_URL:?...}/api/v1/..."` with `FORGEJO_URL` unset fails immediately with the helpful error string.
- [ ] Confirm grep returns nothing: `grep -rn "inside\.h2os\.cloud" skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)