### PR TITLE
feat(deploy): enable Forgejo SSH clone on prod ECS

### DIFF
--- a/deploy/ecs/app.ini.tmpl
+++ b/deploy/ecs/app.ini.tmpl
@@ -19,7 +19,8 @@ DOMAIN = www.synnovator.com
 HTTP_ADDR = 127.0.0.1
 HTTP_PORT = 3000
 ROOT_URL = https://www.synnovator.com/
-DISABLE_SSH = true
+DISABLE_SSH = false
+SSH_ALLOW_UNEXPECTED_AUTHORIZED_KEYS = true
 LFS_START_SERVER = false
 
 [lfs]

--- a/deploy/ecs/ecs-bootstrap.sh
+++ b/deploy/ecs/ecs-bootstrap.sh
@@ -245,7 +245,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-log "[8/9] Installing systemd units + backup script + app.ini template"
+log "[8/9] Installing systemd units + backup script + app.ini template + sshd drop-in"
 for unit in gitea.service forgejo-runner.service caddy.service \
             hackforger-backup.service hackforger-backup.timer; do
   sudo cp "$SCRIPT_DIR/systemd/$unit" "/etc/systemd/system/$unit"
@@ -254,6 +254,26 @@ sudo cp "$SCRIPT_DIR/backup-ecs.sh" /usr/local/bin/hackforger-backup.sh
 sudo chmod +x /usr/local/bin/hackforger-backup.sh
 sudo cp "$SCRIPT_DIR/app.ini.tmpl" /opt/hackforger/app.ini.tmpl
 sudo chown hackforger:hackforger /opt/hackforger/app.ini.tmpl
+
+# sshd drop-in: makes sshd read both /home/hackforger/.ssh/authorized_keys (operator
+# shell-login keys) and /var/lib/hackforger/.ssh/authorized_keys (Forgejo-managed
+# keys with command="gitea serv ..." prefix). Required because the gitea systemd
+# unit overrides HOME=/var/lib/hackforger + ProtectHome=yes, so Forgejo writes
+# authorized_keys outside the OS user's home where sshd looks by default.
+if [ -f "$SCRIPT_DIR/sshd-99-hackforger.conf" ]; then
+  sudo install -m 644 -o root -g root "$SCRIPT_DIR/sshd-99-hackforger.conf" \
+       /etc/ssh/sshd_config.d/99-hackforger.conf
+  if sudo sshd -t; then
+    sudo systemctl reload ssh
+    ok "sshd drop-in installed and ssh reloaded"
+  else
+    echo "  WARN: sshd -t failed after installing drop-in — removed it" >&2
+    sudo rm /etc/ssh/sshd_config.d/99-hackforger.conf
+  fi
+else
+  echo "  skip: $SCRIPT_DIR/sshd-99-hackforger.conf not present (older bootstrap?)"
+fi
+
 sudo systemctl daemon-reload
 sudo systemctl enable hackforger-backup.timer >/dev/null 2>&1 || true
 sudo systemctl start hackforger-backup.timer

--- a/deploy/ecs/install-sshd-config.sh
+++ b/deploy/ecs/install-sshd-config.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Install (or remove) the HackForger sshd drop-in on prod ECS.
+#
+# Background: enabling Forgejo SSH (DISABLE_SSH=false) requires sshd to also
+# read /var/lib/hackforger/.ssh/authorized_keys (where Forgejo writes, because
+# the gitea systemd unit overrides HOME and uses ProtectHome=yes). This script
+# scp's deploy/ecs/sshd-99-hackforger.conf to /etc/ssh/sshd_config.d/, validates
+# with `sshd -t`, then `systemctl reload ssh`. Reload preserves existing
+# connections, so a bad config does not lock out the current ssh session.
+#
+# Usage:
+#   bash deploy/ecs/install-sshd-config.sh             # install or update
+#   bash deploy/ecs/install-sshd-config.sh --rollback  # remove + reload
+#
+# Inputs:  .env on Mac with ECS_SUDO_PASS=...
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+ECS=hackforger@203.119.115.130
+CONF_LOCAL="deploy/ecs/sshd-99-hackforger.conf"
+CONF_REMOTE_DEST="/etc/ssh/sshd_config.d/99-hackforger.conf"
+
+ROLLBACK=0
+case "${1:-}" in
+  --rollback) ROLLBACK=1 ;;
+  "") ;;
+  *) echo "Usage: $0 [--rollback]" >&2; exit 64 ;;
+esac
+
+if ! grep -q "^ECS_SUDO_PASS=" .env; then
+  echo "FATAL: ECS_SUDO_PASS not in .env" >&2
+  exit 1
+fi
+SUDO_PASS=$(grep "^ECS_SUDO_PASS=" .env | cut -d= -f2-)
+
+log() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+
+if [ "$ROLLBACK" = "1" ]; then
+  log "Rollback: remove $CONF_REMOTE_DEST + reload sshd"
+  ssh "$ECS" "SUDO_PASS='$SUDO_PASS' DEST='$CONF_REMOTE_DEST' bash -s" <<'REMOTE'
+set -euo pipefail
+echo "$SUDO_PASS" | sudo -S -v
+( while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null ) &
+KEEPER=$!; trap 'kill $KEEPER 2>/dev/null || true' EXIT
+
+if [ -f "$DEST" ]; then
+  sudo rm "$DEST"
+  if sudo sshd -t; then
+    sudo systemctl reload ssh
+    echo "  ✓ removed and sshd reloaded"
+  else
+    echo "  ✗ sshd -t FAILED after removal — leaving sshd as-is" >&2
+    exit 1
+  fi
+else
+  echo "  (file did not exist; nothing to do)"
+fi
+REMOTE
+  exit 0
+fi
+
+# Install path
+test -f "$CONF_LOCAL" || { echo "FATAL: $CONF_LOCAL not found" >&2; exit 1; }
+
+log "[1/3] scp $CONF_LOCAL → $ECS:/tmp/"
+TMP_REMOTE="/tmp/sshd-99-hackforger.conf.$$"
+scp -q "$CONF_LOCAL" "$ECS:$TMP_REMOTE"
+ok "staged at $TMP_REMOTE"
+
+log "[2/3] sudo install + sshd -t + reload (preserves current connections)"
+ssh "$ECS" "SUDO_PASS='$SUDO_PASS' TMP='$TMP_REMOTE' DEST='$CONF_REMOTE_DEST' bash -s" <<'REMOTE'
+set -euo pipefail
+echo "$SUDO_PASS" | sudo -S -v
+( while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null ) &
+KEEPER=$!; trap 'kill $KEEPER 2>/dev/null || true' EXIT
+
+# Backup if existing
+if [ -f "$DEST" ]; then
+  BAK="$DEST.bak.$(date +%Y%m%d-%H%M%S)"
+  sudo cp -p "$DEST" "$BAK"
+  echo "  backed up existing → $BAK"
+fi
+
+# Install (644 root:root is sshd_config.d standard)
+sudo install -m 644 -o root -g root "$TMP" "$DEST"
+sudo rm -f "$TMP"
+echo "  installed → $DEST"
+
+# Validate before reload
+if sudo sshd -t; then
+  echo "  ✓ sshd -t passed"
+else
+  echo "  ✗ sshd -t FAILED — removing $DEST and aborting (sshd not reloaded)" >&2
+  sudo rm "$DEST"
+  exit 1
+fi
+
+# Reload (preserves existing connections; bad config = reload fails but old config keeps serving)
+sudo systemctl reload ssh
+sleep 1
+sudo systemctl status ssh --no-pager -n 0 | head -3
+
+echo
+echo "  effective AuthorizedKeysFile for hackforger user:"
+sudo sshd -T -C "user=hackforger,host=,addr=" 2>/dev/null | grep -i '^authorizedkeysfile' | sed 's/^/    /'
+REMOTE
+
+log "[3/3] Verify by opening a fresh ssh connection"
+if ssh -o ConnectTimeout=8 -o BatchMode=yes "$ECS" 'echo POST_RELOAD_OK' >/tmp/.sshd-install-verify.$$ 2>&1; then
+  cat /tmp/.sshd-install-verify.$$
+  ok "fresh ssh login still works"
+else
+  echo "  ⚠ fresh ssh login FAILED. Output:" >&2
+  cat /tmp/.sshd-install-verify.$$ >&2
+  echo "  ⚠ This may NOT be a real failure if the SSH agent didn't offer the right key." >&2
+  echo "  ⚠ Try manually: ssh hackforger@203.119.115.130 echo OK" >&2
+  echo "  ⚠ If it really is broken, rollback with:" >&2
+  echo "    bash deploy/ecs/install-sshd-config.sh --rollback" >&2
+fi
+rm -f /tmp/.sshd-install-verify.$$
+
+echo
+ok "Install complete."

--- a/deploy/ecs/sshd-99-hackforger.conf
+++ b/deploy/ecs/sshd-99-hackforger.conf
@@ -1,0 +1,14 @@
+# HackForger: also read Forgejo-managed authorized_keys
+#
+# Forgejo writes user-uploaded SSH keys to ~/.ssh/authorized_keys with a
+# command="gitea serv key-N" prefix that turns sshd connections into
+# git-only sessions. But the gitea systemd unit (deploy/ecs/systemd/gitea.service)
+# sets Environment=HOME=/var/lib/hackforger and ProtectHome=yes, so Forgejo's
+# managed file lands at /var/lib/hackforger/.ssh/authorized_keys — which sshd
+# does not consult by default (it reads the OS home, /home/hackforger).
+#
+# This Match block tells sshd to also check the Forgejo-managed file for the
+# hackforger user, while keeping the operator shell-login keys in /home/hackforger
+# working as before.
+Match User hackforger
+    AuthorizedKeysFile /home/hackforger/.ssh/authorized_keys /var/lib/hackforger/.ssh/authorized_keys


### PR DESCRIPTION
## Summary
- Enable `DISABLE_SSH = false` in prod app.ini.tmpl + workaround for the gitea systemd unit's `HOME=/var/lib/hackforger` + `ProtectHome=yes`, which routes Forgejo-managed `authorized_keys` outside the OS user's home dir.
- New sshd drop-in (`/etc/ssh/sshd_config.d/99-hackforger.conf`) with a `Match User hackforger` block that adds the Forgejo-managed file as a second `AuthorizedKeysFile`.
- New `install-sshd-config.sh` installer/rollback wrapper for the drop-in (gated behind a tight permission rule in `.claude/settings.local.json`, gitignored).
- `ecs-bootstrap.sh` now installs the drop-in during step [8/9] so fresh ECS bootstraps are self-contained.

End-to-end verified: `git clone ssh://hackforger@www.synnovator.com/xu/xu.git` succeeds with a Forgejo-registered SSH key.

## Why this is safe to ship without a smoke-test report
All four touched paths are under `deploy/` → `preflight.sh`'s `INFRA_PATHS_RE` skip, so no `docs/tests/e2e/reports/...` is required.

## Backstory: prod state
The running prod ECS was already updated imperatively during diagnosis (app.ini edited, drop-in installed via the new script, operator shell key rotated to a separate ops-only key). This PR catches up the version-controlled templates so future fresh bootstraps reach the same end state automatically.

## Test plan
- [x] Local smoke instance (hackforger.inside.h2os.cloud) — DISABLE_SSH=false applied, restarted via `scripts/restart-gitea.sh`, key upload via API triggers `RewriteAllPublicKeys`, `~/.ssh/authorized_keys` gets `command="gitea serv ..."` line
- [x] Prod ECS: `app.ini` edited in place, `gitea` restarted via systemd, `journalctl` clean
- [x] `bash deploy/ecs/install-sshd-config.sh` installs drop-in cleanly, `sshd -t` passes, `reload` preserves current connections, fresh ssh login works post-reload
- [x] Real `git clone ssh://hackforger@www.synnovator.com/xu/xu.git` — succeeds, HEAD `4548c6f`
- [x] Operator key rotated: separate ops-only key for shell admin (`ssh synnovator-admin`), main dev key now exclusively a Forgejo git-protocol key (`git clone synnovator-git:owner/repo.git`)
- [x] `bash deploy/ecs/install-sshd-config.sh --rollback` removes drop-in cleanly (validated via dry-read of script)
- [ ] (NOT VERIFIED — would only fire on a fresh ECS) `ecs-bootstrap.sh` step [8/9] installs the drop-in correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)