### PR TITLE
feat(landing): update rules text and open W2 registration (#154 #155)

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -7,9 +7,9 @@
 <meta name="theme-color" content="#222222" media="(prefers-color-scheme: dark)"/>
 <meta name="theme-color" content="#EEEEEE" media="(prefers-color-scheme: light)"/>
 <title>第二届燕缘·协创者号 AI+ 国际创业大赛 | SynNovator</title>
-<meta name="description" content="S1 即刻启动 · 数智 OPC 加速赛：赛规、奖励、组织架构与社区一站直达。"/>
+<meta name="description" content="S1 · 数智 OPC 加速赛：赛规、奖励、组织架构与社区一站直达。"/>
 <meta property="og:title" content="第二届燕缘·协创者号 AI+ 国际创业大赛"/>
-<meta property="og:description" content="S1 即刻启动 · 数智 OPC 加速赛"/>
+<meta property="og:description" content="S1 · 数智 OPC 加速赛"/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="/lingang-2026"/>
 <link rel="canonical" href="/lingang-2026"/>
@@ -715,7 +715,7 @@
 window.HACKFORGER_LANDING_CONFIG = {
   stages: {
     's1-w1': { slug: 'opc-2026-shuzhi-w1',      enabled: true  },
-    's1-w2': { slug: 'opc-2026-shuzhi-w2',      enabled: false },
+    's1-w2': { slug: 'opc-2026-shuzhi-w2',      enabled: true  },
     's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: false },
     's1-w4': { slug: 'opc-2026-shuzhi-w4',      enabled: false },
     's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: false },
@@ -887,10 +887,10 @@ window.HACKFORGER_LANDING_CONFIG = {
 <p class="p3"><b>二、组织架构</b></p>
 <ul class="ul1">
   <li class="li5"><b>指导单位：</b>中共上海市委宣传部、上海市经济和信息化委员会、上海市数据局、上海市人才工作局、上海市科学技术委员会、共青团上海市委员会、中国（上海）自由贸易试验区临港新片区管理委员会</li>
-  <li class="li5"><b>主办单位：</b>上海临港北京大学国际科技创新中心、南汇新城镇人民政府、临港新片区团工委</li>
+  <li class="li5"><b>主办单位：</b>上海临港北京大学国际科技创新中心、南汇新城镇人民政府</li>
   <li class="li5"><b>承办单位：</b>智道元生（上海）技术有限公司、中国电信股份有限公司上海分公司</li>
   <li class="li5"><b>协办单位：</b>青年报社、上海临港科技创新城经济发展有限公司、上海市数字企业出海服务协会、上海临港新片区数字基建投资发展有限公司、上海智慧城市发展研究院、燕缘孵化器</li>
-  <li class="li5"><b>创投支持单位：</b>上海国投科创、上海国投未来、上海国投赋能、临港集团、临港青年创业基金、燕缘创投等</li>
+  <li class="li5"><b>创投支持单位：</b>上海国投科创、上海国投未来、上海国投赋能、临港集团、临港青年创业基金、燕缘创投</li>
 </ul>
 <p class="p6"><br></p>
 <ul class="ul1">
@@ -966,8 +966,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 </ul>
 <p class="p3">活动奖励发放给团队，由团队队长决定奖励分配和使用。</p>
 <p class="p3"><b>（二）报名链接</b></p>
-<p class="p3">扫描下方二维码（或点击链接），通过唯一官方指定渠道报名。</p>
-<p class="p12">【落地页二维码】</p>
+<p class="p3">进入 https://www.synnovator.com ，选择您要报名的赛段活动进入活动详情页报名。</p>
 <p class="p13"><br></p>
 <p class="p13"><br></p>
 <ul class="ul1">
@@ -1319,7 +1318,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <span class="inline-block font-bold font-oppo bg-primary" style="color: rgba(0,0,0,1); border-radius: 2px; padding: clamp(4px, 0.6vw, 8px) clamp(8px, 1vw, 14px); font-size: clamp(10px, 1.05vw, 13px); letter-spacing: 0.04em; line-height: 1.3;">滴水湖全球OPC人工智能挑战赛</span>
 <span class="inline-block font-bold font-oppo bg-primary" style="color: rgba(0,0,0,1); border-radius: 2px; padding: clamp(4px, 0.6vw, 8px) clamp(8px, 1vw, 14px); font-size: clamp(10px, 1.05vw, 13px); letter-spacing: 0.04em; line-height: 1.3;">第二届燕缘·协创者号AI+国际创业大赛</span>
 </div>
-<h1 class="hero-title text-white font-black tracking-tighter leading-[1.05] font-oppo" style="font-size: clamp(26px, 5.4vw, 60px); margin: 0;">S1即刻启动·数智OPC加速赛</h1>
+<h1 class="hero-title text-white font-black tracking-tighter leading-[1.05] font-oppo" style="font-size: clamp(26px, 5.4vw, 60px); margin: 0;">S1·数智OPC加速赛</h1>
 <p class="hero-subtitle text-white/90 font-medium w-full min-w-0 leading-snug font-oppo" style="font-size: clamp(12px, 1.4vw, 17px); margin: 0;">带上你的龙虾队友，协创者号社区提供养料，全球抢真实企业订单</p>
 <div class="flex flex-wrap items-center" style="gap: clamp(8px, 1vw, 14px); margin-top: clamp(4px, 0.8vw, 10px);">
 <button type="button" class="bg-primary text-on-primary font-bold hover:scale-[0.98] transition-transform rounded-full leading-tight font-oppo" style="padding: clamp(8px, 1vw, 12px) clamp(20px, 2.4vw, 32px); font-size: clamp(12px, 1.2vw, 15px);" onclick="var el=document.getElementById('opc-stage-register');if(el)el.scrollIntoView({behavior:'smooth',block:'start'})">立即报名</button>
@@ -1594,7 +1593,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月6日-5月8日</span>
 </div>
-<button data-stage="s1-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">立即报名</button>
+<button data-stage="s1-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">查看详情</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1606,7 +1605,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月10日-5月15日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s1-w2" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月7日开始报名</button>
+<button data-stage="s1-w2" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">立即报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -3221,10 +3220,11 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "密码": "Password",
         "取消": "Cancel",
         // ---- Hero ----
-        "S1即刻启动·数智OPC加速赛": "S1 Live · Digital OPC Sprint",
+        "S1·数智OPC加速赛": "S1 · Digital OPC Sprint",
         "带上你的龙虾队友，协创者号社区提供养料，全球抢真实企业订单":
             "Bring your AI co-pilot. Get fueled by SynNovator. Win real enterprise orders worldwide.",
         "立即报名": "Register Now",
+        "查看详情": "View Details",
         "赛规详情": "Full Rules",
         "共创未来 AI 生产力": "CO-CREATE FUTURE AI PRODUCTIVITY",
         "数智化跨境贸易新纪元": "A New Era of AI Cross-Border Trade",
@@ -3373,9 +3373,8 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "参赛方式：": "How to Enter:",
         // ---- Indicator small phrases ----
         "本届大赛": "This edition",
-        "扫描下方二维码（或点击链接），通过唯一官方指定渠道报名。":
-            "Scan the QR code below (or click the link) to register via the only official channel.",
-        "【落地页二维码】": "[Landing-page QR]",
+        "进入 https://www.synnovator.com ，选择您要报名的赛段活动进入活动详情页报名。":
+            "Go to https://www.synnovator.com, pick the stage you want to enter, and complete registration on its detail page.",
         // ---- Rewards section ----
         "全球首个支持人类与智能体“全流程无差别”协创马拉松比赛平台":
             "The first global Buildathon platform where humans and agents co-create as equals.",


### PR DESCRIPTION
## Summary

Two issues bundled (both touch only `custom/public/assets/landing/index.html`):

### Closes #154 — rules-modal text edits
- 主办单位：去掉 `、临港新片区团工委`
- 创投支持单位：去掉末尾 `等`
- `（二）报名链接` 段：把 "扫描下方二维码…" + "【落地页二维码】" 两行换成 `进入 https://www.synnovator.com ，选择您要报名的赛段活动进入活动详情页报名。`
- Hero 标题：`S1即刻启动·数智OPC加速赛` → `S1·数智OPC加速赛`（同步 meta description / og:description / 内嵌 i18n key）

### Closes #155 — S1W2 报名按钮开放
- `HACKFORGER_LANDING_CONFIG.stages['s1-w2'].enabled` 从 `false` 翻到 `true`，事件代理会把点击导到 `/hackathon/opc-2026-shuzhi-w2`
- W2 卡片：移除 `disabled aria-disabled="true"` 灰按钮 "5月7日开始报名"，换成与 W1 同款 enabled "立即报名"
- W1 卡片：按钮文案 `立即报名` → `查看详情`（链接行为不变）
- i18n 字典追加 `查看详情 → View Details`

## Test plan

- [ ] dev 机 `bash scripts/restart-gitea.sh`
- [ ] `https://hackforger.inside.h2os.cloud/` 访问落地页
- [ ] hero 标题文案中/英 + 深/浅色 4 组合检查
- [ ] 规则按钮 modal："二、组织架构" 主办+创投单位、"（二）报名链接" 段
- [ ] W1 卡片按钮 = "查看详情"，点击跳 `/hackathon/opc-2026-shuzhi-w1`
- [ ] W2 卡片按钮 = "立即报名"（启用），点击跳 `/hackathon/opc-2026-shuzhi-w2`
- [ ] 截图 + 报告 → `docs/tests/e2e/reports/2026-05-08-issue-154-155-landing-text-and-w2-button.md`（admin_signoff: null，待领导）

🤖 Generated with [Claude Code](https://claude.com/claude-code)