### PR TITLE
fix(landing): rename W2 slug to opc-2026-shuzhi-w2-july (#165)

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -715,7 +715,7 @@
 window.HACKFORGER_LANDING_CONFIG = {
   stages: {
     's1-w1': { slug: 'opc-2026-shuzhi-w1',      enabled: true  },
-    's1-w2': { slug: 'opc-2026-shuzhi-w2',      enabled: true  },
+    's1-w2': { slug: 'opc-2026-shuzhi-w2-july', enabled: true  },
     's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: false },
     's1-w4': { slug: 'opc-2026-shuzhi-w4',      enabled: false },
     's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: false },


### PR DESCRIPTION
## Summary

- 把 landing 页 S1W2 按钮指向的 hackathon slug 从 `opc-2026-shuzhi-w2` 改为 `opc-2026-shuzhi-w2-july`，跟随运营在 #165 重建的新 W2 活动
- 单文件单行改动：`custom/public/assets/landing/index.html:718`
- Closes #165

## 背景

运营反馈：原 `opc-2026-shuzhi-w2` 因为赛段信息错误且无法在线修改，已重建为 `opc-2026-shuzhi-w2-july`，落地页按钮需要跟新 slug 走。

## 环境就绪验证

| 环境 | `/hackathon/opc-2026-shuzhi-w2-july` | 结果 |
|---|---|---|
| dev (`hackforger.inside.h2os.cloud`) | ✅ 200 | 直接 curl 验证 |
| prod (`www.synnovator.com`) | ✅ 200 | 直接 curl 验证 |

新活动两边都已经存在，本 PR 合并后按钮链接 dev/prod 都不会 404。

## 关于环境耦合

按钮链接由 [`handleRegisterClick()`](custom/public/assets/landing/index.html#L757) 中的相对路径 `/hackathon/<slug>` 拼接，浏览器从 `document.location` 自动继承 host/scheme。所以同一份文件部署到 dev / prod 任意环境，按钮都会跳到当前域名下的 hackathon 页，**不会出现 prod 用户被引导到 dev 链接**的问题。

## Test plan

- [x] 本地 grep 确认改动只一行
- [x] dev/prod 两端 `/hackathon/opc-2026-shuzhi-w2-july` 200
- [ ] 合并后 dev 机重启 gitea，浏览器实测 W2 按钮跳到新 slug
- [ ] E2E 报告 + screenshot
- [ ] admin signoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)