### PR TITLE
Orphan-binary restart guard for dev Macs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ All new code lives in `*/hackforger/` directories, minimizing changes to upstrea
 - `go test ./models/hackforger/... -v` -- Run model tests
 - `go test ./services/hackforger/... -v` -- Run service tests
 - `./gitea web` -- Start server (http://localhost:3000)
-- `bash scripts/restart-gitea.sh` -- **After merging a PR**: one-command atomic rebuild + restart of the main instance. Does: build → stop-if-binary-path-matches → start → verify HTTP 200. Refuses to kill port-3000 processes whose binary path isn't the main repo's `gitea`, so it's safe to automate.
+- `bash scripts/restart-gitea.sh` -- **After merging a PR**: one-command atomic rebuild + restart of the main instance. Does: build → stop-if-binary-path-matches → start → verify HTTP 200. Refuses to kill port-3000 processes whose binary path isn't the main repo's `gitea`, so it's safe to automate. If you ever see `pre-receive ... No such file or directory` on push, you're in orphan-binary state — see [docs/notes/orphan-binary.md](docs/notes/orphan-binary.md).
 - `bash scripts/restart-gitea-test.sh` -- Same flow for the **test instance** (port 3001, `--custom-path /tmp/hackforger-test-custom`, log at `/tmp/gitea-test.log`). Use after editing test app.ini or rebuilding while it's up.
 - Restart server manually (fallback): kill old process, remove LevelDB lock (`rm -f data/queues/common/LOCK`), then start
 

--- a/docs/notes/orphan-binary.md
+++ b/docs/notes/orphan-binary.md
@@ -1,0 +1,61 @@
+# Orphan-Binary State on Dev Macs
+
+When you see this on `git push` to `localhost:3000` (or `:3001`):
+
+```
+remote: ./hooks/pre-receive.d/gitea: line 3:/Users/h2oslabs/Workspace/hackforger/gitea: No such file or directory
+remote: error: hook declined to update refs/heads/...
+! [remote rejected] ... (pre-receive hook declined)
+```
+
+…the dev instance is in **orphan-binary state**. This note explains what it means, how to fix it, and why production is immune.
+
+## What it means
+
+The `gitea` binary at `/Users/h2oslabs/Workspace/hackforger/gitea` was deleted while the `gitea web` process was still running. Common causes:
+
+- `make clean` while the server was up
+- A manual `rm gitea`
+- A rebuild that crashed mid-way (rare)
+- Switching between worktrees that reuse the path
+
+Unix `unlink()` only removes the **directory entry** that names the inode. The inode itself stays alive as long as some process still holds it open. `gitea web` mapped the binary into its address space at startup (`txt` segment in `lsof`), so it keeps that inode alive and continues serving HTTP normally. But hooks are short-lived child processes — they invoke `exec()` on the **path** `/Users/.../gitea`, which the kernel resolves by name. The name no longer exists, so `exec()` fails with `ENOENT`. Every git push fails. HTTP traffic looks fine.
+
+## Self-diagnosis
+
+```bash
+PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t)
+lsof -p "$PID" | awk '/txt.*\/gitea$/{print $NF}'
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+```
+
+If `lsof` prints a path and `ls` says `No such file or directory` on that same path → orphan state.
+
+(On macOS, `lsof` does **not** append `(deleted)` to the path the way Linux does — you have to compare against the filesystem yourself.)
+
+## Fix
+
+```bash
+bash scripts/restart-gitea.sh        # for the main instance (port 3000)
+bash scripts/restart-gitea-test.sh   # for the test instance (port 3001)
+```
+
+The restart script builds first, asserts the binary exists, then kills + restarts. After a clean run, pushes work again.
+
+If you run a patched (post-2026-05-11) version of the script, you'll see a banner before the build telling you the orphan state was detected — that's expected and means the script is doing its job.
+
+## Why production isn't affected
+
+Production ECS uses `sudo install -m 755 /tmp/gitea-new /opt/hackforger/gitea` in `deploy/ecs/redeploy.sh:113`. `install(1)` is an atomic rename — the path always points to a valid inode. The old running process holds the old inode (same `unlink-while-open` mechanism!), but the path resolves to the new inode for any hook fork. There's no window during which the path is empty, so prod hooks never `ENOENT`.
+
+## Prevention
+
+- Don't `rm gitea` while `gitea web` is running. If you must, run `bash scripts/restart-gitea.sh` immediately afterwards.
+- `make clean` will likely remove the binary — restart afterwards.
+- If unsure, check with the self-diagnosis snippet above.
+
+## See also
+
+- `scripts/restart-gitea.sh` and `scripts/restart-gitea-test.sh` — the recovery commands
+- `deploy/ecs/redeploy.sh:113` — the prod atomic-replace pattern this dev guard approximates
+- `docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md` — the design behind the patch

--- a/docs/notes/orphan-binary.md
+++ b/docs/notes/orphan-binary.md
@@ -42,7 +42,7 @@ bash scripts/restart-gitea-test.sh   # for the test instance (port 3001)
 
 The restart script builds first, asserts the binary exists, then kills + restarts. After a clean run, pushes work again.
 
-If you run a patched (post-2026-05-11) version of the script, you'll see a banner before the build telling you the orphan state was detected — that's expected and means the script is doing its job.
+If your `scripts/restart-gitea.sh` prints an `⚠ Orphan-binary state detected` banner before `[1/4] Building backend`, that's the diagnostic doing its job — it just confirmed why your last push failed, and the build below will fix it.
 
 ## Why production isn't affected
 
@@ -51,7 +51,7 @@ Production ECS uses `sudo install -m 755 /tmp/gitea-new /opt/hackforger/gitea` i
 ## Prevention
 
 - Don't `rm gitea` while `gitea web` is running. If you must, run `bash scripts/restart-gitea.sh` immediately afterwards.
-- `make clean` will likely remove the binary — restart afterwards.
+- `make clean` removes the binary (Makefile target `clean-no-bindata` deletes `$(EXECUTABLE)`) — restart afterwards.
 - If unsure, check with the self-diagnosis snippet above.
 
 ## See also

--- a/docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md
+++ b/docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md
@@ -1,0 +1,633 @@
+# Orphan-Binary Restart Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the "running gitea + missing on-disk binary" state visible at restart time, prevent the restart script from making it worse, and document the phenomenon.
+
+**Architecture:** Two surgical additions to each of the two restart scripts (pre-flight diagnostic + post-build assertion), plus a new explainer doc and a one-line cross-reference in `CLAUDE.md`. No upstream Forgejo Go changes; no shared bash library; no monitoring; no production-side changes.
+
+**Tech Stack:** Bash 3.2 (macOS default), `lsof`, plain Markdown. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md`
+
+---
+
+## Pre-flight (do this once before starting)
+
+- [ ] **P0.1: Confirm current working state**
+
+Run from `/Users/h2oslabs/Workspace/hackforger`:
+
+```bash
+git status
+git log --oneline -5
+ls -la scripts/restart-gitea.sh scripts/restart-gitea-test.sh CLAUDE.md
+ls -d docs/notes docs/superpowers/specs docs/superpowers/plans
+```
+
+Expected: clean tree (or only the spec + plan files we just added), both restart scripts present, target directories all exist.
+
+- [ ] **P0.2: Confirm the current orphan state (this is our "live test fixture")**
+
+```bash
+PID_MAIN=$(lsof -iTCP:3000 -sTCP:LISTEN -t)
+PID_TEST=$(lsof -iTCP:3001 -sTCP:LISTEN -t)
+echo "main pid=$PID_MAIN test pid=$PID_TEST"
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea 2>&1
+```
+
+Expected: both PIDs non-empty, `ls` reports `No such file or directory`. **Do not run any restart-* script yet** — we want this state preserved as a fixture until Task 1 step 4.
+
+If the binary already exists (someone rebuilt it), the orphan-banner verification in Task 1 step 4 will need a different fixture — see the alternate-path note in that step.
+
+---
+
+## Task 1: Add pre-flight orphan diagnostic to `restart-gitea.sh`
+
+**Files:**
+- Modify: `scripts/restart-gitea.sh` (insert after line 15 `cd "$REPO"`)
+
+This is Change A from the spec. The block is purely informational; it runs **before** `make build` so that the cause is visible upfront rather than buried under 30 seconds of compile output.
+
+- [ ] **Step 1: Read the current file in full to lock in the exact context**
+
+```bash
+cat -n scripts/restart-gitea.sh
+```
+
+Expected: 62 lines. Confirm line 15 is `cd "$REPO"` and line 17 is `echo "[1/4] Building backend (bindata + sqlite tags)..."`. If line numbers have drifted, re-anchor on the literal strings, not on numbers.
+
+- [ ] **Step 2: Document the "failing test" state**
+
+Without invoking the script, write down what current behavior is in orphan state:
+
+> Running `bash scripts/restart-gitea.sh` against an orphan instance prints nothing about the orphan condition — the cause of any prior push failures is invisible. The user sees `[1/4] Building backend ...` and has no way to know they were already broken before this run.
+
+This is the gap Task 1 closes.
+
+- [ ] **Step 3: Insert the pre-flight diagnostic block**
+
+Edit `scripts/restart-gitea.sh`. Find the exact block:
+
+```bash
+cd "$REPO"
+
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+```
+
+Replace with:
+
+```bash
+cd "$REPO"
+
+# Pre-flight: detect orphan-binary state (gitea running but $BINARY deleted on disk).
+# Unix unlink-while-open keeps the process alive but git push fails with ENOENT in
+# pre-receive. The rebuild below will recover; this banner just makes the cause
+# visible before make's 30s of output buries it. See docs/notes/orphan-binary.md.
+ORPHAN_PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN_PID" ] && [ ! -e "$BINARY" ]; then
+  echo ""
+  echo "  ⚠ Orphan-binary state detected"
+  echo "    PID $ORPHAN_PID is listening on :3000 but $BINARY no longer exists on disk."
+  echo "    Any git push to this instance has been failing with ENOENT in pre-receive."
+  echo "    This restart will recover. See docs/notes/orphan-binary.md"
+  echo ""
+fi
+
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+```
+
+Style notes:
+- Use `[ ! -e "$BINARY" ]` (not `! [ -e ... ]`) for bash 3.2 portability.
+- `2>/dev/null || true` on `lsof` prevents an early exit under `set -e` if nothing is listening.
+- Variable named `ORPHAN_PID` (not `PID`) to avoid shadowing the `PID` that step `[2/4]` re-derives a few lines below — we keep that block untouched for blast-radius reasons.
+
+- [ ] **Step 4: Syntax-check, then run the script**
+
+```bash
+bash -n scripts/restart-gitea.sh && echo "syntax ok"
+```
+
+Expected: `syntax ok`.
+
+Then **run the script** against the current orphan fixture:
+
+```bash
+bash scripts/restart-gitea.sh
+```
+
+Expected output (in order):
+1. The new orphan banner (4 indented lines with the warning, before `[1/4]`).
+2. `[1/4] Building backend ...` followed by Go build output.
+3. `[2/4] ... Stopping main instance (PID <ORPHAN_PID>, binary /Users/h2oslabs/Workspace/hackforger/gitea)`.
+4. `[3/4] Starting new instance...`.
+5. `[4/4] ... ✓ HTTP 200 on localhost:3000`.
+
+Alternate path (if the orphan fixture was already healed before this step):
+- Run `ls /Users/h2oslabs/Workspace/hackforger/gitea`; if the binary now exists, the banner will not fire this run. That's still correct behavior (test 1 from the verification matrix). Move on; we'll re-verify the banner in Task 3 step 5 against the test instance's likely-still-orphan fixture, or by deliberately `rm`'ing the binary while a process holds it open.
+
+- [ ] **Step 5: Confirm the actual recovery worked (push end-to-end on the now-rebuilt instance)**
+
+```bash
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+lsof -iTCP:3000 -sTCP:LISTEN -t
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/
+```
+
+Expected: binary present, single PID listening, HTTP 200.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/restart-gitea.sh
+git commit -m "$(cat <<'EOF'
+scripts: add orphan-binary pre-flight diagnostic to restart-gitea.sh
+
+Surfaces the "gitea running + on-disk binary deleted" state at the top of
+the restart flow so the cause of preceding push failures is visible before
+the 30s build step buries it. Informational only — does not alter control
+flow. The existing build-first ordering already handles recovery.
+
+See docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+EOF
+)"
+```
+
+---
+
+## Task 2: Add post-build binary assertion to `restart-gitea.sh`
+
+**Files:**
+- Modify: `scripts/restart-gitea.sh` (insert between current `make build` line and the `[2/4]` block)
+
+This is Change B from the spec. Defends against a pathological `make build` that exits 0 without producing the binary, which would otherwise let us kill the running gitea and end up with nothing to start.
+
+- [ ] **Step 1: Locate the exact insertion point**
+
+```bash
+grep -n 'TAGS=' scripts/restart-gitea.sh
+grep -n '\[2/4\]' scripts/restart-gitea.sh
+```
+
+Expected: `make build` is on the line above `[2/4]`. The assertion goes between them.
+
+- [ ] **Step 2: Insert the assertion**
+
+Find:
+
+```bash
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+echo "[2/4] Checking for process on port 3000..."
+```
+
+Replace with:
+
+```bash
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+# Defensive: make build exited 0 but did it actually produce a runnable binary?
+# Without this check, a broken Makefile target would let us kill the running
+# instance below and leave us with nothing to start.
+if [ ! -x "$BINARY" ]; then
+  echo "FATAL: make build returned 0 but $BINARY is missing or non-executable." >&2
+  echo "       Refusing to kill the running instance — that would leave you with nothing to start." >&2
+  exit 1
+fi
+
+echo "[2/4] Checking for process on port 3000..."
+```
+
+- [ ] **Step 3: Syntax-check + happy-path re-run**
+
+```bash
+bash -n scripts/restart-gitea.sh && echo "syntax ok"
+bash scripts/restart-gitea.sh
+```
+
+Expected: `syntax ok`, then a clean run (no banner this time — we're healthy), HTTP 200 at the end. The assertion silently passes because `make build` produces a real binary.
+
+- [ ] **Step 4: Sabotaged-build verification (optional but recommended)**
+
+This is the test that exercises the assertion. Simulate a Makefile that lies:
+
+```bash
+# Save the real binary, simulate "build produced nothing"
+mv /Users/h2oslabs/Workspace/hackforger/gitea /tmp/gitea.real
+
+# Stub PATH so `make build` is a no-op
+mkdir -p /tmp/stub
+cat > /tmp/stub/make <<'STUB'
+#!/bin/bash
+echo "stub make: pretending to build $@"
+exit 0
+STUB
+chmod +x /tmp/stub/make
+
+# Run the script with the stub in front
+PATH=/tmp/stub:$PATH bash scripts/restart-gitea.sh
+RC=$?
+echo "exit code: $RC"
+
+# Verify: assertion fired, no kill happened
+lsof -iTCP:3000 -sTCP:LISTEN -t
+```
+
+Expected:
+- Script prints `FATAL: make build returned 0 but ... is missing` and exits 1.
+- `lsof` still shows the original PID — **the running gitea was NOT killed**.
+- Exit code: 1.
+
+Cleanup:
+
+```bash
+mv /tmp/gitea.real /Users/h2oslabs/Workspace/hackforger/gitea
+rm -rf /tmp/stub
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea  # confirm restored
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/restart-gitea.sh
+git commit -m "$(cat <<'EOF'
+scripts: add post-build binary assertion to restart-gitea.sh
+
+If `make build` exits 0 without producing $BINARY (e.g., regressed Makefile
+target, partial build, surface-area change), abort before the kill step so
+we don't leave the host with nothing to start. Refuses to kill the running
+instance in that case.
+
+See docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+EOF
+)"
+```
+
+---
+
+## Task 3: Mirror both changes to `restart-gitea-test.sh`
+
+**Files:**
+- Modify: `scripts/restart-gitea-test.sh`
+
+The test-instance script is a near-duplicate of the main one. Both new blocks are mirrored verbatim with `:3000` replaced by `:$PORT` (the test script parametrises the port).
+
+- [ ] **Step 1: Read the current test script**
+
+```bash
+cat -n scripts/restart-gitea-test.sh
+```
+
+Expected: 70 lines. Confirm it uses `$PORT` (set to 3001 at the top) rather than a hardcoded port number in the lsof block.
+
+- [ ] **Step 2: Insert pre-flight diagnostic (mirror of Task 1)**
+
+Find:
+
+```bash
+cd "$REPO"
+
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+```
+
+Replace with:
+
+```bash
+cd "$REPO"
+
+# Pre-flight: detect orphan-binary state. See docs/notes/orphan-binary.md.
+ORPHAN_PID=$(lsof -iTCP:$PORT -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN_PID" ] && [ ! -e "$BINARY" ]; then
+  echo ""
+  echo "  ⚠ Orphan-binary state detected"
+  echo "    PID $ORPHAN_PID is listening on :$PORT but $BINARY no longer exists on disk."
+  echo "    Any git push to this instance has been failing with ENOENT in pre-receive."
+  echo "    This restart will recover. See docs/notes/orphan-binary.md"
+  echo ""
+fi
+
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+```
+
+- [ ] **Step 3: Insert post-build assertion (mirror of Task 2)**
+
+Find:
+
+```bash
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+echo "[2/4] Checking for process on port $PORT..."
+```
+
+Replace with:
+
+```bash
+echo "[1/4] Building backend (bindata + sqlite tags)..."
+TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+# Defensive: make build exited 0 but did it actually produce a runnable binary?
+if [ ! -x "$BINARY" ]; then
+  echo "FATAL: make build returned 0 but $BINARY is missing or non-executable." >&2
+  echo "       Refusing to kill the running instance — that would leave you with nothing to start." >&2
+  exit 1
+fi
+
+echo "[2/4] Checking for process on port $PORT..."
+```
+
+- [ ] **Step 4: Syntax-check**
+
+```bash
+bash -n scripts/restart-gitea-test.sh && echo "syntax ok"
+```
+
+Expected: `syntax ok`.
+
+- [ ] **Step 5: Run against the test instance (likely still orphan)**
+
+```bash
+lsof -iTCP:3001 -sTCP:LISTEN -t
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+```
+
+If both show: PID listening AND binary present → instance is already healthy; running the script should print no banner and complete cleanly.
+
+If PID listening AND binary missing → orphan fixture exists; banner should fire.
+
+Actually run it:
+
+```bash
+bash scripts/restart-gitea-test.sh
+```
+
+Expected: banner if-and-only-if orphan, then a clean build + restart, HTTP 200 on `:3001`.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/
+```
+
+Expected: `200`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/restart-gitea-test.sh
+git commit -m "$(cat <<'EOF'
+scripts: mirror orphan-binary guards to restart-gitea-test.sh
+
+Adds the same pre-flight orphan diagnostic and post-build binary assertion
+that restart-gitea.sh got, parametrised on $PORT for the test instance.
+
+See docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+EOF
+)"
+```
+
+---
+
+## Task 4: Write `docs/notes/orphan-binary.md`
+
+**Files:**
+- Create: `docs/notes/orphan-binary.md`
+
+The explainer note. ~50 lines, six sections per spec section C.
+
+- [ ] **Step 1: Confirm `docs/notes/` exists and pick a neighbour-style for tone**
+
+```bash
+ls docs/notes/ | head -5
+head -30 docs/notes/i18n-error-pattern.md 2>/dev/null || head -30 docs/notes/cross-origin-protection.md 2>/dev/null
+```
+
+Expected: directory exists, neighbouring notes use short titles, plain Markdown, mix of zh-CN/en-US text — match whatever style is current.
+
+- [ ] **Step 2: Create the note**
+
+Write to `docs/notes/orphan-binary.md`. Note: the outer fence below uses **four** backticks so the inner three-backtick fences in the file content are preserved verbatim.
+
+````markdown
+# Orphan-Binary State on Dev Macs
+
+When you see this on `git push` to `localhost:3000` (or `:3001`):
+
+```
+remote: ./hooks/pre-receive.d/gitea: line 3:/Users/h2oslabs/Workspace/hackforger/gitea: No such file or directory
+remote: error: hook declined to update refs/heads/...
+! [remote rejected] ... (pre-receive hook declined)
+```
+
+…the dev instance is in **orphan-binary state**. This note explains what it means, how to fix it, and why production is immune.
+
+## What it means
+
+The `gitea` binary at `/Users/h2oslabs/Workspace/hackforger/gitea` was deleted while the `gitea web` process was still running. Common causes:
+
+- `make clean` while the server was up
+- A manual `rm gitea`
+- A rebuild that crashed mid-way (rare)
+- Switching between worktrees that reuse the path
+
+Unix `unlink()` only removes the **directory entry** that names the inode. The inode itself stays alive as long as some process still holds it open. `gitea web` mapped the binary into its address space at startup (`txt` segment in `lsof`), so it keeps that inode alive and continues serving HTTP normally. But hooks are short-lived child processes — they invoke `exec()` on the **path** `/Users/.../gitea`, which the kernel resolves by name. The name no longer exists, so `exec()` fails with `ENOENT`. Every git push fails. HTTP traffic looks fine.
+
+## Self-diagnosis
+
+```bash
+PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t)
+lsof -p "$PID" | awk '/txt.*\/gitea$/{print $NF}'
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+```
+
+If `lsof` prints a path and `ls` says `No such file or directory` on that same path → orphan state.
+
+(On macOS, `lsof` does **not** append `(deleted)` to the path the way Linux does — you have to compare against the filesystem yourself.)
+
+## Fix
+
+```bash
+bash scripts/restart-gitea.sh        # for the main instance (port 3000)
+bash scripts/restart-gitea-test.sh   # for the test instance (port 3001)
+```
+
+The restart script builds first, asserts the binary exists, then kills + restarts. After a clean run, pushes work again.
+
+If you run a patched (post-2026-05-11) version of the script, you'll see a banner before the build telling you the orphan state was detected — that's expected and means the script is doing its job.
+
+## Why production isn't affected
+
+Production ECS uses `sudo install -m 755 /tmp/gitea-new /opt/hackforger/gitea` in `deploy/ecs/redeploy.sh:113`. `install(1)` is an atomic rename — the path always points to a valid inode. The old running process holds the old inode (same `unlink-while-open` mechanism!), but the path resolves to the new inode for any hook fork. There's no window during which the path is empty, so prod hooks never `ENOENT`.
+
+## Prevention
+
+- Don't `rm gitea` while `gitea web` is running. If you must, run `bash scripts/restart-gitea.sh` immediately afterwards.
+- `make clean` will likely remove the binary — restart afterwards.
+- If unsure, check with the self-diagnosis snippet above.
+
+## See also
+
+- `scripts/restart-gitea.sh` and `scripts/restart-gitea-test.sh` — the recovery commands
+- `deploy/ecs/redeploy.sh:113` — the prod atomic-replace pattern this dev guard approximates
+- `docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md` — the design behind the patch
+````
+
+- [ ] **Step 3: Render-check**
+
+```bash
+ls -la docs/notes/orphan-binary.md
+wc -l docs/notes/orphan-binary.md
+```
+
+Expected: file exists, between 45 and 65 lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/notes/orphan-binary.md
+git commit -m "$(cat <<'EOF'
+docs: add note on orphan-binary state on dev Macs
+
+Explains the Unix unlink-while-open mechanism that lets gitea keep serving
+HTTP while git push fails with ENOENT, how to self-diagnose, how to fix
+(restart-gitea.sh), and why production ECS isn't affected (atomic install
+in redeploy.sh).
+
+See docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+EOF
+)"
+```
+
+---
+
+## Task 5: Add pointer to `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md` (append a sentence to the `restart-gitea.sh` bullet under **Common Commands**)
+
+- [ ] **Step 1: Find the exact bullet**
+
+```bash
+grep -n 'restart-gitea.sh' CLAUDE.md
+```
+
+Expected: at least one hit; find the bullet under "Common Commands" that begins with `bash scripts/restart-gitea.sh -- **After merging a PR**:`.
+
+- [ ] **Step 2: Append the cross-reference**
+
+Locate the exact line:
+
+```
+- `bash scripts/restart-gitea.sh` -- **After merging a PR**: one-command atomic rebuild + restart of the main instance. Does: build → stop-if-binary-path-matches → start → verify HTTP 200. Refuses to kill port-3000 processes whose binary path isn't the main repo's `gitea`, so it's safe to automate.
+```
+
+Replace with:
+
+```
+- `bash scripts/restart-gitea.sh` -- **After merging a PR**: one-command atomic rebuild + restart of the main instance. Does: build → stop-if-binary-path-matches → start → verify HTTP 200. Refuses to kill port-3000 processes whose binary path isn't the main repo's `gitea`, so it's safe to automate. If you ever see `pre-receive ... No such file or directory` on push, you're in orphan-binary state — see [docs/notes/orphan-binary.md](docs/notes/orphan-binary.md).
+```
+
+- [ ] **Step 3: Sanity check**
+
+```bash
+grep -n 'orphan-binary.md' CLAUDE.md
+```
+
+Expected: exactly one hit, on the modified bullet line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: cross-reference orphan-binary note from CLAUDE.md restart bullet
+
+So future operators (human or Claude) reading CLAUDE.md know where to look
+when they hit the pre-receive ENOENT symptom.
+
+See docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+EOF
+)"
+```
+
+---
+
+## Task 6: End-to-end verification on the restored instance
+
+This is **not a code change**, just a fresh-eyes confirmation that the whole thing works after all five previous tasks are committed.
+
+- [ ] **Step 1: Confirm clean tree and recent history**
+
+```bash
+git status
+git log --oneline -7
+```
+
+Expected: clean tree, last 5 commits match the work above (script A, script B, mirror, doc, CLAUDE.md). Plus the design-spec commit if it was committed separately.
+
+- [ ] **Step 2: End-to-end push test against the now-healthy main instance**
+
+Mirror of the prod verification we did during brainstorming, but pointed at `localhost:3000`:
+
+```bash
+set -a; . .env; set +a
+TS=$(date +%s)
+REPO="precv-local-$TS"
+
+curl -sS -X POST "http://localhost:3000/api/v1/user/repos" \
+  -H "Authorization: token ${FORGEJO_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"${REPO}\",\"auto_init\":true,\"private\":true}" \
+  -o /tmp/r.json -w "HTTP=%{http_code}\n"
+```
+
+If HTTP=201, proceed:
+
+```bash
+WORK="/tmp/${REPO}"
+# FORGEJO_TOKEN is for the dev instance — confirm the local token works here
+OWNER=$(python3 -c "import json; print(json.load(open('/tmp/r.json'))['owner']['login'])")
+AUTH_URL="http://${OWNER}:${FORGEJO_TOKEN}@localhost:3000/${OWNER}/${REPO}.git"
+
+git clone "$AUTH_URL" "$WORK"
+cd "$WORK"
+git config user.email ci@example.com
+git config user.name ci-smoke
+git checkout -b precv-test
+echo "hello $(date)" > smoke.txt
+git add smoke.txt
+git commit -m "precv smoke"
+git push -v origin precv-test
+RC=$?
+cd /
+echo "push exit code: $RC"
+
+curl -sS -X DELETE "http://localhost:3000/api/v1/repos/${OWNER}/${REPO}" \
+  -H "Authorization: token ${FORGEJO_TOKEN}" \
+  -o /tmp/del.json -w "delete HTTP=%{http_code}\n"
+rm -rf "$WORK"
+```
+
+Expected:
+- `push exit code: 0`
+- `delete HTTP=204`
+- The push output contains `* [new branch] precv-test -> precv-test` and the gitea-side "Create a new pull request" hint (proof the hook ran cleanly).
+
+If push fails with `ENOENT` again: the orphan state somehow re-occurred between Task 1 step 5 and here. Re-run `bash scripts/restart-gitea.sh` and try the test again; investigate root cause separately.
+
+- [ ] **Step 3: No commit for this task** — verification only.
+
+---
+
+## What "done" looks like
+
+After all 6 tasks:
+
+1. `scripts/restart-gitea.sh` has two new defensive blocks (orphan diagnostic + post-build assertion).
+2. `scripts/restart-gitea-test.sh` has the same two blocks, parametrised on `$PORT`.
+3. `docs/notes/orphan-binary.md` exists and explains the phenomenon end-to-end.
+4. `CLAUDE.md` cross-references the new note from the `restart-gitea.sh` bullet.
+5. End-to-end git push against `localhost:3000` succeeds with exit 0.
+6. Five commits land on the current branch, each scoped to one task.
+
+No changes to production. No changes to upstream Forgejo Go code. No new monitoring. No script consolidation.

--- a/docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md
+++ b/docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md
@@ -211,7 +211,9 @@ Expected: `syntax ok`, then a clean run (no banner this time — we're healthy),
 
 - [ ] **Step 4: Sabotaged-build verification (optional but recommended)**
 
-This is the test that exercises the assertion. Simulate a Makefile that lies:
+This is the test that exercises the assertion. Simulate a Makefile that lies.
+
+**Note on the test itself**: this temporarily creates an orphan-binary state (we `mv` the real binary aside while gitea on :3000 keeps holding the inode). The assertion firing **prevents** the kill, so the running gitea is preserved throughout. Cleanup restores the binary. There is a ~10-second window where any concurrent git push against :3000 would fail — fine on a dev box, do not run this on shared instances.
 
 ```bash
 # Save the real binary, simulate "build produced nothing"
@@ -346,27 +348,44 @@ bash -n scripts/restart-gitea-test.sh && echo "syntax ok"
 
 Expected: `syntax ok`.
 
-- [ ] **Step 5: Run against the test instance (likely still orphan)**
+- [ ] **Step 5: Deliberately create an orphan fixture and verify the banner fires**
+
+Rather than relying on the test instance's pre-existing state (which Task 1's earlier rebuild may have healed if the test instance shares the same `$BINARY`), force the orphan state so the banner is guaranteed to be exercised at least once:
 
 ```bash
-lsof -iTCP:3001 -sTCP:LISTEN -t
-ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+# Ensure the test instance is up and holding the binary open
+lsof -iTCP:3001 -sTCP:LISTEN -t || bash scripts/restart-gitea-test.sh
+
+# Create orphan fixture: move binary aside while both gitea processes
+# keep it open via the existing mmap'd text segments.
+mv /Users/h2oslabs/Workspace/hackforger/gitea /tmp/gitea.orphan-fixture
+ls /Users/h2oslabs/Workspace/hackforger/gitea 2>&1  # should report "No such file or directory"
 ```
 
-If both show: PID listening AND binary present → instance is already healthy; running the script should print no banner and complete cleanly.
-
-If PID listening AND binary missing → orphan fixture exists; banner should fire.
-
-Actually run it:
+Now run the patched test script:
 
 ```bash
 bash scripts/restart-gitea-test.sh
 ```
 
-Expected: banner if-and-only-if orphan, then a clean build + restart, HTTP 200 on `:3001`.
+Expected output:
+- The new orphan banner fires (4 indented lines naming PID, port `:3001`, and the missing path).
+- `[1/4] Building backend ...` rebuilds the binary at the path.
+- Assertion B silently passes.
+- `[2/4]` stops the test instance, `[3/4]` starts a fresh one, `[4/4]` reports HTTP 200.
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/
+ls -la /Users/h2oslabs/Workspace/hackforger/gitea
+rm -f /tmp/gitea.orphan-fixture  # the moved-aside binary is now stale; the rebuilt one supersedes it
+```
+
+Expected: `200`, binary present, fixture removed.
+
+**Side effect to be aware of**: this also leaves the **main** instance on :3000 in an orphan state for a few seconds (it was holding the same binary), but the rebuild restored the path before the test script's [2/4] kicked in. The main instance is still healthy at the end of this step — confirm with:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/
 ```
 
 Expected: `200`.

--- a/docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
+++ b/docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md
@@ -1,0 +1,134 @@
+---
+date: 2026-05-11
+status: approved
+owner: claude + jjkysy
+---
+
+# Orphan-Binary Restart Guard
+
+## Problem
+
+On dev Macs, the `gitea` binary at `/Users/h2oslabs/Workspace/hackforger/gitea` can be deleted while the running `gitea` process is still alive (via `make clean`, manual `rm`, an aborted rebuild, or a worktree shuffle). Unix unlink-while-open semantics keep the running process healthy — it serves HTTP fine — but every git push fails because each repo's `hooks/pre-receive.d/gitea` script `exec`s the path:
+
+```
+/Users/h2oslabs/Workspace/hackforger/gitea hook --config=… pre-receive
+```
+
+…and the path now resolves to nothing. Symptom on the client side:
+
+```
+remote: ./hooks/pre-receive.d/gitea: line 3:/Users/h2oslabs/Workspace/hackforger/gitea: No such file or directory
+remote: error: hook declined to update refs/heads/…
+! [remote rejected] … (pre-receive hook declined)
+error: failed to push some refs
+```
+
+Production ECS is immune: `deploy/ecs/redeploy.sh` uses `sudo install -m 755 /tmp/gitea-new /opt/hackforger/gitea`, which is an atomic rename — the path always points to a valid inode. Verified empirically 2026-05-11 by an end-to-end push test against `https://www.synnovator.com`.
+
+## Goals
+
+1. The orphan state becomes **visible** at the moment a human is most likely to notice — restart time.
+2. The orphan state becomes **recoverable** by a single one-line command the developer already knows.
+3. The restart script will **not** make the situation worse (e.g., killing the running process when no replacement binary exists).
+4. The phenomenon is documented so future operators (human or Claude) recognize it on sight.
+
+## Non-Goals
+
+- No changes to upstream Forgejo Go code (e.g., teaching hook templates to use `os.Executable()` at exec time). Maintenance cost in our fork outweighs the value for a dev-only failure mode.
+- No periodic monitoring / launchd healthchecker. Out of scope for this iteration.
+- No production-side changes. Production is already covered by the `install(1)` atomic-replace pattern in `redeploy.sh`.
+- No script consolidation/refactor between `restart-gitea.sh` and `restart-gitea-test.sh`. They remain near-duplicates (~70 lines each); the cost of factoring out a shared library exceeds the benefit at this size.
+
+## Design
+
+### Change set
+
+| File | Change | Lines |
+|---|---|---|
+| `scripts/restart-gitea.sh` | Add (A) pre-flight orphan diagnostic, (B) post-build binary assertion | +~15 |
+| `scripts/restart-gitea-test.sh` | Mirror the same two changes | +~15 |
+| `docs/notes/orphan-binary.md` | New explainer note (~50 lines) | new |
+| `CLAUDE.md` | One-line pointer next to the `restart-gitea.sh` bullet | +1 |
+
+### A. Pre-flight orphan diagnostic
+
+Inserted at the **very top of `main`**, before `make build`. Purely informational; does not abort.
+
+Logic:
+
+1. `PID = lsof -iTCP:$PORT -sTCP:LISTEN -t` — current listener on the script's target port.
+2. If `PID` is non-empty AND `! -e $BINARY` on disk → print a banner.
+
+Banner content (each script substitutes its own `$PORT` and `$BINARY`):
+
+```
+⚠ Orphan-binary state detected
+  PID $PID is listening on :$PORT but $BINARY no longer exists on disk.
+  Any git push to this instance has been failing with ENOENT in pre-receive.
+  This restart will recover. See docs/notes/orphan-binary.md
+```
+
+Implementation note: the existing script computes `PID` only inside step `[2/4]`. The new block needs its own local `PID` lookup at the top so the banner can print before `make build` starts (which itself takes 30s+ and obscures the cause). The variable is shadowed and recomputed in step `[2/4]` — kept as-is to minimize blast radius.
+
+### B. Post-build binary assertion
+
+Inserted **after `make build` returns, before the kill step** (i.e., between current line 18 and current line 20 of both scripts).
+
+```bash
+[ -x "$BINARY" ] || {
+  echo "FATAL: make build returned 0 but $BINARY is missing or non-executable." >&2
+  echo "       Refusing to kill the running instance — that would leave you with nothing to start." >&2
+  exit 1
+}
+```
+
+Defends against pathological cases where the Makefile target succeeds without producing the expected output (e.g., target name changed, output dir moved, partial build, surface-area regression). Without this check, the script would proceed to kill the running gitea and then fail to start anything — exactly the "make it worse" failure we want to prevent.
+
+### C. `docs/notes/orphan-binary.md`
+
+New markdown note covering:
+
+1. **What it looks like** — exact client-side error string, server-log signature.
+2. **Why it happens** — one-paragraph explanation of unlink-while-open: directory entry deleted, but the kernel keeps the inode alive because the running process still has it mapped (`txt` segment). HTTP keeps working (no path resolution). `exec()` of the path fails (path resolution required).
+3. **Self-diagnosis** — `lsof -p <pid> | awk '/txt.*\/gitea$/{print $NF}'` returns the path; compare with `ls`. If `ls` says "No such file or directory" while `lsof` shows the path, you're in this state.
+4. **Fix** — `bash scripts/restart-gitea.sh` (and the test-instance variant). The script rebuilds and restarts atomically; the new prod-style behavior is in place.
+5. **Why production is unaffected** — one paragraph on `redeploy.sh`'s `install(1)` atomic replace. Cross-reference `deploy/ecs/redeploy.sh:113`.
+6. **Prevention** — don't manually `rm gitea` or `make clean` while gitea is running; if you do, immediately run the restart script.
+
+### D. `CLAUDE.md` pointer
+
+Append a single trailing sentence to the existing `restart-gitea.sh` bullet (≈ line 84 of CLAUDE.md, under **Common Commands**):
+
+> If you ever see `pre-receive ... No such file or directory` on push, you're in the orphan-binary state — see [docs/notes/orphan-binary.md](docs/notes/orphan-binary.md).
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Pre-flight detects orphan state | Banner printed; script continues (banner is advisory, the rebuild is the fix) |
+| `make build` fails | Existing `set -euo pipefail` aborts before kill. Unchanged. |
+| `make build` exit 0 but binary missing | New assertion B catches it; abort with explicit message; running gitea **not** killed |
+| Port held by a foreign binary | Existing safety check unchanged — still refuses to kill |
+| Nothing on the port | Unchanged: skip kill, build + start |
+
+## Verification Matrix
+
+| # | Setup | Expected |
+|---|---|---|
+| 1 | Healthy: binary present, gitea running | No banner; full clean restart; HTTP 200 |
+| 2 | Orphan: `rm $BINARY`, gitea still listening | Banner appears at top; `make build` rebuilds binary; kill + restart succeeds; HTTP 200 |
+| 3 | Sabotaged build: stub `make build` to `exit 0` without producing binary | Assertion B fires; exit 1 with explicit message; **running gitea untouched**; port-3000 unchanged |
+| 4 | No process on port, binary present | No banner; build + start; HTTP 200 |
+| 5 | No process on port, binary missing | Banner does **not** fire (no running PID to be orphaned); `make build` rebuilds; start; HTTP 200 |
+
+Manual verification on a developer Mac is sufficient — no unit test harness for these scripts.
+
+## Open Questions
+
+None. The design is intentionally minimal and additive; existing script behavior is preserved.
+
+## Reference
+
+- Root-cause debug session (2026-05-11): identified the unlink-while-open mechanism via `lsof` inode comparison between PID 67188 (port 3000) and PID 49461 (port 3001) — two different inodes for the same missing path.
+- Production verification (2026-05-11): end-to-end push test on `https://www.synnovator.com` succeeded with exit 0. Throwaway repo `SynNovator/precv-repro-*` created, pushed, and deleted (HTTP 204) — see conversation transcript.
+- Related: `deploy/ecs/redeploy.sh:113` (the atomic-install pattern this design aims to approximate in dev).

--- a/scripts/restart-gitea-test.sh
+++ b/scripts/restart-gitea-test.sh
@@ -23,8 +23,26 @@ LOG="/tmp/gitea-test.log"
 
 cd "$REPO"
 
+# Pre-flight: detect orphan-binary state. See docs/notes/orphan-binary.md.
+ORPHAN_PID=$(lsof -iTCP:$PORT -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN_PID" ] && [ ! -e "$BINARY" ]; then
+  echo "" >&2
+  echo "  ⚠ Orphan-binary state detected" >&2
+  echo "    PID $ORPHAN_PID is listening on :$PORT but $BINARY no longer exists on disk." >&2
+  echo "    Any git push to this instance has been failing with ENOENT in pre-receive." >&2
+  echo "    This restart will recover. See docs/notes/orphan-binary.md" >&2
+  echo "" >&2
+fi
+
 echo "[1/4] Building backend (bindata + sqlite tags)..."
 TAGS="bindata sqlite sqlite_unlock_notify" make build
+
+# Defensive: make build exited 0 but did it actually produce a runnable binary?
+if [ ! -x "$BINARY" ]; then
+  echo "FATAL: make build returned 0 but $BINARY is missing or non-executable." >&2
+  echo "       Refusing to kill the running instance — that would leave you with nothing to start." >&2
+  exit 1
+fi
 
 echo "[2/4] Checking for process on port $PORT..."
 PID=$(lsof -iTCP:$PORT -sTCP:LISTEN -t 2>/dev/null || true)

--- a/scripts/restart-gitea.sh
+++ b/scripts/restart-gitea.sh
@@ -14,6 +14,20 @@ BINARY="$REPO/gitea"
 
 cd "$REPO"
 
+# Pre-flight: detect orphan-binary state (gitea running but $BINARY deleted on disk).
+# Unix unlink-while-open keeps the process alive but git push fails with ENOENT in
+# pre-receive. The rebuild below will recover; this banner just makes the cause
+# visible before make's 30s of output buries it. See docs/notes/orphan-binary.md.
+ORPHAN_PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN_PID" ] && [ ! -e "$BINARY" ]; then
+  echo ""
+  echo "  ⚠ Orphan-binary state detected"
+  echo "    PID $ORPHAN_PID is listening on :3000 but $BINARY no longer exists on disk."
+  echo "    Any git push to this instance has been failing with ENOENT in pre-receive."
+  echo "    This restart will recover. See docs/notes/orphan-binary.md"
+  echo ""
+fi
+
 echo "[1/4] Building backend (bindata + sqlite tags)..."
 TAGS="bindata sqlite sqlite_unlock_notify" make build
 

--- a/scripts/restart-gitea.sh
+++ b/scripts/restart-gitea.sh
@@ -31,6 +31,15 @@ fi
 echo "[1/4] Building backend (bindata + sqlite tags)..."
 TAGS="bindata sqlite sqlite_unlock_notify" make build
 
+# Defensive: make build exited 0 but did it actually produce a runnable binary?
+# Without this check, a broken Makefile target would let us kill the running
+# instance below and leave us with nothing to start.
+if [ ! -x "$BINARY" ]; then
+  echo "FATAL: make build returned 0 but $BINARY is missing or non-executable." >&2
+  echo "       Refusing to kill the running instance — that would leave you with nothing to start." >&2
+  exit 1
+fi
+
 echo "[2/4] Checking for process on port 3000..."
 PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t 2>/dev/null || true)
 if [ -n "$PID" ]; then

--- a/scripts/restart-gitea.sh
+++ b/scripts/restart-gitea.sh
@@ -20,12 +20,12 @@ cd "$REPO"
 # visible before make's 30s of output buries it. See docs/notes/orphan-binary.md.
 ORPHAN_PID=$(lsof -iTCP:3000 -sTCP:LISTEN -t 2>/dev/null || true)
 if [ -n "$ORPHAN_PID" ] && [ ! -e "$BINARY" ]; then
-  echo ""
-  echo "  ⚠ Orphan-binary state detected"
-  echo "    PID $ORPHAN_PID is listening on :3000 but $BINARY no longer exists on disk."
-  echo "    Any git push to this instance has been failing with ENOENT in pre-receive."
-  echo "    This restart will recover. See docs/notes/orphan-binary.md"
-  echo ""
+  echo "" >&2
+  echo "  ⚠ Orphan-binary state detected" >&2
+  echo "    PID $ORPHAN_PID is listening on :3000 but $BINARY no longer exists on disk." >&2
+  echo "    Any git push to this instance has been failing with ENOENT in pre-receive." >&2
+  echo "    This restart will recover. See docs/notes/orphan-binary.md" >&2
+  echo "" >&2
 fi
 
 echo "[1/4] Building backend (bindata + sqlite tags)..."


### PR DESCRIPTION
## Summary

- Detects the "running `gitea` + missing on-disk binary" state at the top of `scripts/restart-gitea.sh` and `scripts/restart-gitea-test.sh`, printing a stderr banner before the build so the cause of preceding `git push` failures is visible up front instead of buried under 30 seconds of compile output.
- Asserts the binary exists after `make build` returns 0, and refuses to kill the running instance if it doesn't — preventing the script itself from making a half-broken state fully broken in pathological build cases.
- Adds [`docs/notes/orphan-binary.md`](docs/notes/orphan-binary.md) explaining the Unix `unlink-while-open` mechanism, self-diagnosis snippet, fix command, and why production is immune (it uses `install(1)` atomic-replace in `deploy/ecs/redeploy.sh:113`).
- One-line cross-reference from `CLAUDE.md` so future operators hitting the `pre-receive ... No such file or directory` symptom find the explanation immediately.

## Scope discipline

- **Production is unaffected.** Scripts hardcode `REPO=/Users/h2oslabs/Workspace/hackforger` and apply only to dev Macs. Cloud ECS already uses `install(1)` atomic replace, which is the prod-side version of what this PR approximates for dev. Verified live 2026-05-11 via an end-to-end push against `https://www.synnovator.com`.
- **No upstream Forgejo Go code changes.** The hook-template path-baking behavior is Forgejo's by design.
- **No monitoring / launchd healthchecker** (option C from brainstorm, deferred).
- **Two restart scripts intentionally remain near-duplicates.** Shared-library extraction was considered and rejected at the spec stage; revisit at N=3 callers or when guard logic grows branching.

## Design + plan artifacts

- Spec: [`docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md`](docs/superpowers/specs/2026-05-11-orphan-binary-restart-guard-design.md)
- Plan: [`docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md`](docs/superpowers/plans/2026-05-11-orphan-binary-restart-guard.md)

Both went through independent reviewer subagents before implementation. The plan got one reviewer-driven tightening (Task 3 Step 5 strengthened to deliberately create an orphan fixture instead of relying on the test instance's pre-existing state) — see commit `d248a9e3b0`. Implementation followed the plan with two small reviewer-suggested polishes (banner to stderr; tightened phrasings in the note).

## Test plan

- [x] Live recovery on `:3000` — patched `restart-gitea.sh` ran against the actual orphan fixture this Mac was in (`/Users/h2oslabs/Workspace/hackforger/gitea` missing while gitea PID 67188 was alive); banner fired with the correct PID, rebuild succeeded, kill+restart succeeded, HTTP 200 confirmed.
- [x] Sabotaged-build assertion exercise — temporarily moved binary aside and PATH-stubbed `make` to return 0 without producing output; assertion fired, exit 1, **running gitea preserved** (`lsof` confirmed PID unchanged before/after). Cleanup restored binary.
- [x] Mirror on `:3001` — `restart-gitea-test.sh` ran with a deliberately-created orphan fixture; banner fired with `PID 49461` and port `:3001`; rebuild succeeded.
- [x] End-to-end push against patched `:3000` — created a temp repo via API, cloned, committed, pushed; push exit 0; gitea-internal "Create a new pull request" hint received (proves pre-receive hook ran cleanly via `exec` of the freshly-rebuilt binary); cleanup HTTP 204.

## Known out-of-scope observation

The test instance on `:3001` currently returns HTTP 502 due to a **separate, pre-existing** missing-config issue (`/tmp/hackforger-test-custom/conf/app.ini` was gone before this PR started; the running PID 49461 was holding its config in memory from startup 9 days ago). Once we restarted it, the new process couldn't find the config and self-aborted. This is a different unlink-while-open-style problem (this time on a config file, not the binary) and out of scope here. The Task 3 code change itself is correct — the banner fired exactly as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)