### PR TITLE
feat(landing): open S2W1 / S3W1 registration and fill pulse stat numbers

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -718,11 +718,11 @@ window.HACKFORGER_LANDING_CONFIG = {
     's1-w2': { slug: 'opc-2026-shuzhi-w2-july', enabled: true  },
     's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: false },
     's1-w4': { slug: 'opc-2026-shuzhi-w4',      enabled: false },
-    's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: false },
+    's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: true  },
     's2-w2': { slug: 'opc-2026-crossborder-w2', enabled: false },
     's2-w3': { slug: 'opc-2026-crossborder-w3', enabled: false },
     's2-w4': { slug: 'opc-2026-crossborder-w4', enabled: false },
-    's3-w1': { slug: 'opc-2026-youth-w1',       enabled: false },
+    's3-w1': { slug: 'opc-2026-youth-w1',       enabled: true  },
     's3-w2': { slug: 'opc-2026-youth-w2',       enabled: false },
     's3-w3': { slug: 'opc-2026-youth-w3',       enabled: false },
     's3-w4': { slug: 'opc-2026-youth-w4',       enabled: false }
@@ -1418,7 +1418,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="w-2.5 h-2.5 shrink-0 rounded-full animate-pulse bg-black"></div>
 <span class="pulse-compute-kicker font-bold tracking-[0.3em] uppercase text-black block text-[16px] leading-none font-oppo">算力消耗</span>
 </div>
-<p class="text-4xl md:text-5xl font-bold tracking-tighter leading-none mb-2 text-on-primary">即将发送</p>
+<p class="text-4xl md:text-5xl font-bold tracking-tighter leading-none mb-2 text-on-primary">500万+token</p>
 <p class="text-[10px] font-bold uppercase tracking-widest text-on-primary/85 font-oppo">大赛累计消耗🦞算力虾粮</p>
 </div>
 </div>
@@ -1427,7 +1427,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="w-2.5 h-2.5 shrink-0 rounded-full animate-pulse bg-brand-orange"></div>
 <span class="pulse-issued-kicker font-bold tracking-[0.3em] uppercase text-brand-orange block text-[16px] leading-none font-oppo">总计发放</span>
 </div>
-<p class="text-4xl md:text-5xl font-bold tracking-tighter text-on-surface leading-none mb-2">即将发送</p>
+<p class="text-4xl md:text-5xl font-bold tracking-tighter text-on-surface leading-none mb-2">30+只</p>
 <p class="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-oppo">已发放龙虾🦞数</p>
 </div>
 <div class="pulse-live-card rounded-md p-6 md:p-8 flex flex-col items-start h-full min-h-[143px] md:min-h-[160px] cursor-pointer select-none transition-all duration-200 hover:-translate-y-0.5 active:scale-[0.995] focus:outline-none" data-info-id="pulse-live" role="button" tabindex="0" aria-label="正在进行 说明">
@@ -1435,7 +1435,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="w-2.5 h-2.5 shrink-0 rounded-full animate-pulse bg-brand-pink"></div>
 <span class="font-bold tracking-[0.3em] uppercase text-brand-pink block text-[16px] leading-none font-oppo">正在进行</span>
 </div>
-<p id="pulse-live-count" class="text-4xl md:text-5xl font-bold tracking-tighter leading-none mb-2 text-on-surface">即将发送</p>
+<p id="pulse-live-count" class="text-4xl md:text-5xl font-bold tracking-tighter leading-none mb-2 text-on-surface">30+只</p>
 <p class="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-oppo">活跃在线龙虾🦞数</p>
 </div>
 </div>
@@ -1657,7 +1657,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月27日-5月29日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s2-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月11日开始报名</button>
+<button data-stage="s2-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">即刻报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1724,7 +1724,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">6月25日-7月2日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s3-w1" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月11日开始报名</button>
+<button data-stage="s3-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">即刻报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -3224,6 +3224,7 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "带上你的龙虾队友，协创者号社区提供养料，全球抢真实企业订单":
             "Bring your AI co-pilot. Get fueled by SynNovator. Win real enterprise orders worldwide.",
         "立即报名": "Register Now",
+        "即刻报名": "Register Now",
         "查看详情": "View Details",
         "赛规详情": "Full Rules",
         "共创未来 AI 生产力": "CO-CREATE FUTURE AI PRODUCTIVITY",
@@ -3260,6 +3261,8 @@ body.lang-en #share-modal p { line-height: 1.55; font-size: 14px; }
         "总计发放": "Total Issued",
         "正在进行": "Live Now",
         "即将发送": "Coming soon",
+        "500万+token": "5M+ tokens",
+        "30+只": "30+",
         // ---- Section: rewards ----
         "超高奖励": "High-Value Rewards",
         // ---- Section: tasks ----


### PR DESCRIPTION
## Summary
- 开放 S2W1（跨境OPC加速赛 初赛）和 S3W1（全球青年培育赛 初赛）的报名按钮：从灰底 disabled "5月11日开始报名" 翻成主色调 active "即刻报名"，点击跳 `/hackathon/opc-2026-crossborder-w1` 和 `/hackathon/opc-2026-youth-w1`（线上 200 已验证）
- 替换三张 pulse 统计卡的 "即将发送" 占位：算力消耗 → **500万+token**，总计发放 → **30+只**，正在进行 → **30+只**（reporter 确认目前只发了一轮，故两张数字相同）
- 同步补三条英文 i18n 映射

## Closes
Closes #171

## Changes
仅一个文件，单段静态资源改动：
- `custom/public/assets/landing/index.html`（+10 / -7）

## Test plan
- [ ] 合并到 `v0.1-dev/hackforger` 后跑 `bash scripts/restart-gitea.sh`（虽然静态资源严格说不必，但走标准 E2E 流程）
- [ ] 浏览器访问 https://hackforger.inside.h2os.cloud
- [ ] 中文页：S2W1 / S3W1 按钮显示 "即刻报名"、主色调、可点击；点击跳转到对应活动页
- [ ] 中文页：三张 pulse 卡分别显示 "500万+token / 30+只 / 30+只"，副标题不变
- [ ] 英文页（lang 切换）：按钮显 "Register Now"，统计卡显 "5M+ tokens / 30+ / 30+"
- [ ] 提交 E2E 报告至 `docs/tests/e2e/reports/YYYY-MM-DD-landing-s2w1-s3w1.md`，admin_signoff 留空待 admin 填

## Notes
- Cynthialime 在 issue 评论里明确 "只改按钮文字"，所以卡片上 "报名开启：5月11日起" 副标题不动
- 现役 S1W2 用 "立即报名"，本次 S2W1/S3W1 用 "即刻报名" 是 reporter 的有意区分；中英 i18n 都映射到 "Register Now" 以避免英文页出现两种译法

🤖 Generated with [Claude Code](https://claude.com/claude-code)