### PR TITLE
feat(landing): open S1W3 registration button

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -716,7 +716,7 @@ window.HACKFORGER_LANDING_CONFIG = {
   stages: {
     's1-w1': { slug: 'opc-2026-shuzhi-w1',      enabled: true  },
     's1-w2': { slug: 'opc-2026-shuzhi-w2-july', enabled: true  },
-    's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: false },
+    's1-w3': { slug: 'opc-2026-shuzhi-w3',      enabled: true  },
     's1-w4': { slug: 'opc-2026-shuzhi-w4',      enabled: false },
     's2-w1': { slug: 'opc-2026-crossborder-w1', enabled: true  },
     's2-w2': { slug: 'opc-2026-crossborder-w2', enabled: false },
@@ -1617,7 +1617,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月17日-5月24日</span>
 </div>
-<button disabled aria-disabled="true" data-stage="s1-w3" class="w-full py-3 bg-[#9CA3AF] text-[#4B5563] text-xs md:text-sm font-black rounded-full uppercase tracking-widest font-oppo mt-auto cursor-not-allowed">5月14日开始报名</button>
+<button data-stage="s1-w3" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">即刻报名</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">


### PR DESCRIPTION
## Summary
开放 S1W3（半决赛W3 数智OPC加速赛）的报名按钮：从灰底 disabled "5月14日开始报名" 翻成主色调 active "即刻报名"，点击跳 `/hackathon/opc-2026-shuzhi-w3`（线上 200 已验证）。

与 #172 的 S2W1/S3W1 完全同款改动。

## Closes
Closes #174

## Changes
单文件，2 行：
- `custom/public/assets/landing/index.html`
  - `HACKFORGER_LANDING_CONFIG.stages` 里 `s1-w3` 的 `enabled: false` → `true`
  - S1W3 按钮 disabled → active，文案 "5月14日开始报名" → "即刻报名"

## Notes
- i18n `"即刻报名"→"Register Now"` 已由 #172 带入，本次无需改 locale
- 卡片日期角标 "5月17日-5月24日" 不动（沿用 reporter 在 #171 的 "只改按钮文字"）

## Test plan
- [ ] 合并到 `v0.1-dev/hackforger` 后 `bash scripts/restart-gitea.sh`
- [ ] https://hackforger.inside.h2os.cloud 中文页：S1W3 按钮显 "即刻报名"、主色调、可点击，跳转到 `/hackathon/opc-2026-shuzhi-w3`
- [ ] 英文页：按钮显 "Register Now"
- [ ] E2E 报告 → `docs/tests/e2e/reports/2026-05-14-landing-s1w3.md`，`admin_signoff: null` 待 admin 填

🤖 Generated with [Claude Code](https://claude.com/claude-code)