### PR TITLE
fix(hackathon): show phase custom name on public page (#182)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-phase-custom-name-public-render-design.md
+++ b/docs/superpowers/specs/2026-06-01-phase-custom-name-public-render-design.md
@@ -1,0 +1,70 @@
+# Fix: hackathon stage custom name not shown on public page (issue #182)
+
+## Problem
+
+When an admin edits a hackathon stage (phase) name in the management page, the
+new name is saved to `phase.custom_name` and shown correctly in the management
+UI, but the **public hackathon detail page** keeps showing the phase type's
+default i18n name. Reported on https://www.synnovator.com, reproduces every time.
+
+Reproduced locally (port 3000, `hackforger` DB) on hackathon
+`opc-2026-crossborder-w2`: setting `custom_name` on a phase, the public page
+still rendered the default name (`Registration`); the custom name appeared 0
+times in the page HTML.
+
+## Root cause
+
+Two renderers display phase names and only one honors `custom_name`:
+
+- Management UI (`web_src/js/components/hackforger/PhaseTimeline.vue:59`) —
+  `if (phase.custom_name) return phase.custom_name;` then falls back to the
+  type's default name. **Correct.**
+- Public page (`templates/hackforger/hackathon/view.tmpl:30`) —
+  `{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}` —
+  renders only the type's default i18n name, **never reads `.CustomName`.** Bug.
+
+The data layer is fine: `custom_name` is stored (`models/hackforger/phase.go`)
+and loaded into the template via `GetPhases` → `Phases`. Only the public
+template's display logic is wrong.
+
+## Scope
+
+Single line. Verified the only public template rendering hackathon phase names
+is `view.tmpl:30`. The admin `phase_types.tmpl` edits the type *catalog* (not
+instances) and is correct as-is; the grants timeline uses fixed status keys
+(different feature). No other site affected.
+
+## Change
+
+`templates/hackforger/hackathon/view.tmpl:30`
+
+```go-html-template
+{{/* before */}}
+<div class="hf-step-name">{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+
+{{/* after: custom name wins, fall back to default i18n name (mirrors PhaseTimeline.vue) */}}
+<div class="hf-step-name">{{if .CustomName}}{{.CustomName}}{{else if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+```
+
+### Design points
+
+- **Precedence mirrors the Vue reference**: non-empty `custom_name` wins, else
+  the type's default i18n name. The two renderers finally agree.
+- **Empty-string handling**: `custom_name` defaults to `''`; Go's
+  `{{if .CustomName}}` treats `''` as false, so unedited phases keep their
+  default name.
+- **XSS**: `{{.CustomName}}` is user input but Go `html/template` auto-escapes
+  it. Safe.
+- **No backend/model/migration/i18n changes** — pure display fix.
+
+## Build & verify
+
+- Template-only change → `make backend` (bindata re-embed) + restart. No
+  `make frontend`.
+- E2E: log in as admin → management page → rename a stage → confirm the public
+  page shows the new name; confirm an unedited stage still shows its default.
+
+## Out of scope
+
+- Refactoring the two renderers into one shared source of truth (future).
+- Grant round timeline (unaffected).

--- a/templates/hackforger/hackathon/view.tmpl
+++ b/templates/hackforger/hackathon/view.tmpl
@@ -27,7 +27,7 @@
 		<div class="hf-timeline">
 			{{range .Phases}}
 			<div class="hf-timeline-step {{if .IsLocked}}hf-step-done{{else if .IsActive}}hf-step-active{{else}}hf-step-upcoming{{end}}">
-				<div class="hf-step-name">{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+				<div class="hf-step-name">{{if .CustomName}}{{.CustomName}}{{else if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
 				<div class="hf-step-date">{{DateUtils.AbsoluteShort .StartTime}} — {{DateUtils.AbsoluteShort .EndTime}}</div>
 				<div class="hf-step-status">
 					{{if .IsLocked}}{{ctx.Locale.Tr "hackforger.hackathon.manage.phase.step.done"}}


### PR DESCRIPTION
## Problem
Fixes #182. After an admin edits a hackathon stage (phase) name in the management page, the new name is saved to `phase.custom_name` and shown in the management UI, but the **public hackathon detail page** keeps showing the phase type's default i18n name.

## Root cause
Two renderers display phase names; only one honored `custom_name`:
- Management UI (`PhaseTimeline.vue:59`) — `if (phase.custom_name) return phase.custom_name;` ✅
- Public page (`view.tmpl:30`) — rendered only `PhaseType.DisplayNameI18n`, ignored `CustomName`. ❌

## Fix
One line in `templates/hackforger/hackathon/view.tmpl`: custom name wins, fall back to the type's default i18n name — mirroring the Vue renderer.

```go-html-template
<div class="hf-step-name">{{if .CustomName}}{{.CustomName}}{{else if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
```

Pure display fix — no backend/model/migration/i18n changes. Reviewed by codex (read-only): scope confirmed single template; edge cases (empty string, nil PhaseType, XSS auto-escaping) handled.

Reproduced locally and verified fixed via E2E (see smoke-test report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)