### PR TITLE
fix(hackathon): phase custom name on public page + decouple rename from time guard (#182)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-phase-custom-name-public-render-design.md
+++ b/docs/superpowers/specs/2026-06-01-phase-custom-name-public-render-design.md
@@ -1,0 +1,70 @@
+# Fix: hackathon stage custom name not shown on public page (issue #182)
+
+## Problem
+
+When an admin edits a hackathon stage (phase) name in the management page, the
+new name is saved to `phase.custom_name` and shown correctly in the management
+UI, but the **public hackathon detail page** keeps showing the phase type's
+default i18n name. Reported on https://www.synnovator.com, reproduces every time.
+
+Reproduced locally (port 3000, `hackforger` DB) on hackathon
+`opc-2026-crossborder-w2`: setting `custom_name` on a phase, the public page
+still rendered the default name (`Registration`); the custom name appeared 0
+times in the page HTML.
+
+## Root cause
+
+Two renderers display phase names and only one honors `custom_name`:
+
+- Management UI (`web_src/js/components/hackforger/PhaseTimeline.vue:59`) —
+  `if (phase.custom_name) return phase.custom_name;` then falls back to the
+  type's default name. **Correct.**
+- Public page (`templates/hackforger/hackathon/view.tmpl:30`) —
+  `{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}` —
+  renders only the type's default i18n name, **never reads `.CustomName`.** Bug.
+
+The data layer is fine: `custom_name` is stored (`models/hackforger/phase.go`)
+and loaded into the template via `GetPhases` → `Phases`. Only the public
+template's display logic is wrong.
+
+## Scope
+
+Single line. Verified the only public template rendering hackathon phase names
+is `view.tmpl:30`. The admin `phase_types.tmpl` edits the type *catalog* (not
+instances) and is correct as-is; the grants timeline uses fixed status keys
+(different feature). No other site affected.
+
+## Change
+
+`templates/hackforger/hackathon/view.tmpl:30`
+
+```go-html-template
+{{/* before */}}
+<div class="hf-step-name">{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+
+{{/* after: custom name wins, fall back to default i18n name (mirrors PhaseTimeline.vue) */}}
+<div class="hf-step-name">{{if .CustomName}}{{.CustomName}}{{else if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+```
+
+### Design points
+
+- **Precedence mirrors the Vue reference**: non-empty `custom_name` wins, else
+  the type's default i18n name. The two renderers finally agree.
+- **Empty-string handling**: `custom_name` defaults to `''`; Go's
+  `{{if .CustomName}}` treats `''` as false, so unedited phases keep their
+  default name.
+- **XSS**: `{{.CustomName}}` is user input but Go `html/template` auto-escapes
+  it. Safe.
+- **No backend/model/migration/i18n changes** — pure display fix.
+
+## Build & verify
+
+- Template-only change → `make backend` (bindata re-embed) + restart. No
+  `make frontend`.
+- E2E: log in as admin → management page → rename a stage → confirm the public
+  page shows the new name; confirm an unedited stage still shows its default.
+
+## Out of scope
+
+- Refactoring the two renderers into one shared source of truth (future).
+- Grant round timeline (unaffected).

--- a/docs/tests/e2e/reports/2026-06-01-phase-custom-name-public-render.md
+++ b/docs/tests/e2e/reports/2026-06-01-phase-custom-name-public-render.md
@@ -81,6 +81,36 @@ Fixed by decoupling the name from the time window:
 - Net behavior: renaming works on any phase; changing the **time window** of a
   locked/active phase is still rejected as before.
 
+## Follow-up: tester feedback fixes (round 2)
+
+Tester (Cynthialime) verified on hackforger.inside.h2os.cloud and reported the
+core render fix works, but two UI/handler gaps remained — the first round's
+verification used HTTP requests and missed the real Vue UI:
+
+1. **Ended phases had no rename control.** `PhaseTimeline.vue` rendered the
+   rename (✎) button with `v-if="phaseState(phase) !== 'locked'"`, so ended
+   phases couldn't be renamed in the UI even though the backend allowed it.
+   Fix: always render the rename button (time inputs stay disabled for ended).
+2. **Editing a phase's time wiped its custom name.** The Vue `updatePhase`
+   (time edit) PUTs `{start_time, end_time}` with no `custom_name`; the handler
+   decoded the missing field as `""` and cleared the name. Fix: `custom_name`
+   is now a `*string` in both the web (`routers/web/hackforger/phase.go`) and
+   API (`routers/api/v1/hackforger/phase.go`) handlers — nil = not provided
+   (leave untouched), non-nil sets it (`""` clears). The API handler was also
+   restructured to the same decoupled shape (time-guard only when times change)
+   for web/API parity.
+
+### Verification (round 2)
+
+- **Rename ended phase via the real browser UI**: logged in, opened the manage
+  page, the ended `报名` phase now shows the ✎ button (disabled date inputs);
+  renamed it → DB persisted `已结束阶段改名验证OK` → public page shows it. PASS.
+- **Time edit preserves name** (authenticated PUT, exactly what the Vue sends):
+  set name `FIXB2`, then a successful time-only edit (no `custom_name`) → HTTP
+  200, time changed, name **preserved**; a failed (overlap) time edit also kept
+  the name; explicit `custom_name:""` still clears. PASS.
+- All test values reverted to empty.
+
 ## Admin sign-off
 
 Pending admin manual verification (stage 3).

--- a/docs/tests/e2e/reports/2026-06-01-phase-custom-name-public-render.md
+++ b/docs/tests/e2e/reports/2026-06-01-phase-custom-name-public-render.md
@@ -1,0 +1,86 @@
+---
+title: "Issue #182 — hackathon phase custom name not shown on public page"
+date: 2026-06-01
+issue: 182
+pr: 183
+commits: [984e7893b5fd1a6b4c663664da050a70f38b0938]
+environment:
+  - "localhost:3000 (main instance)"
+  - "https://hackforger.inside.h2os.cloud (smoke domain, via Caddy → 3000)"
+tester: Claude (Opus 4.8) + codex (gpt-5.5) E2E
+result: PASS
+admin_signoff:
+---
+
+# Smoke test: phase custom name on public page (#182)
+
+## Change under test
+
+`templates/hackforger/hackathon/view.tmpl:30` — the public hackathon timeline
+now renders an admin-edited phase `custom_name` (falling back to the phase
+type's default i18n name), mirroring the management UI renderer
+(`PhaseTimeline.vue:59`). Pure display fix; no backend/model/migration/i18n
+changes.
+
+## Reproduction (pre-fix)
+
+On `opc-2026-crossborder-w2`, setting a phase `custom_name` left the public page
+showing the default name; the custom name appeared 0 times in the page HTML.
+The management UI showed the new name — the two renderers disagreed.
+
+## Verification
+
+### Pre-implementation review
+codex (read-only) reviewed the one-line design: correct & complete, scope
+confirmed to the single template, edge cases (empty string, nil PhaseType, XSS
+auto-escaping) handled, precedence (custom wins) correct.
+
+### Stage 1 — localhost E2E (codex, via real management web route)
+
+Full path through the session-authenticated web endpoint
+`PUT /hackathon/opc-2026-crossborder-w2/manage/phases/{id}` (not /api/v1),
+targeting the `results` phase (id 28, not ended):
+
+| Step | Result | Evidence |
+|------|--------|----------|
+| Login as SynNovator | PASS | HTTP 303 |
+| Rename PUT (custom_name set) | PASS | HTTP 200; JSON response contains `custom_name` |
+| Public page renders custom name | PASS | `<div class="hf-step-name">E2E公开页改名验证_RESULTS</div>` |
+| Unedited phase shows default | PASS | `<div class="hf-step-name">开发</div>` |
+| Cleanup (custom_name='') | PASS | HTTP 200; custom string gone from public page |
+
+`E2E RESULT: PASS`
+
+### Stage 2 — smoke domain (hackforger.inside.h2os.cloud, via Caddy)
+
+Set `custom_name='总决赛颁奖盛典FINALS'` on the `results` phase, fetched the
+public page through the real HTTPS domain:
+
+- `GET https://hackforger.inside.h2os.cloud/hackathon/opc-2026-crossborder-w2` → HTTP 200
+- Timeline rendered: `Development / Judging / Registration / 总决赛颁奖盛典FINALS`
+  (custom name shown; other phases show defaults)
+- Browser screenshot confirms the last phase shows「总决赛颁奖盛典FINALS」
+  instead of the default「结果发布」.
+
+All test `custom_name` values were reverted to empty after testing.
+
+## Related handler fix (included in this PR)
+
+A latent bug surfaced during E2E: `ManagePhasesUpdate`
+(`routers/web/hackforger/phase.go`) wrote `custom_name` *unconditionally before*
+the `UpdatePhaseTime` ended-phase guard, so renaming an **ended** phase
+persisted the name in the DB yet returned `403 该阶段已结束，无法修改` — a partial
+write on a failed request.
+
+Fixed by decoupling the name from the time window:
+- The guarded `UpdatePhaseTime` is now invoked **only when start/end actually
+  change**, so it can no longer leave a half-applied name behind.
+- The custom name (a cosmetic label) is persisted via a focused
+  `UpdatePhaseCustomName` (writes only the `custom_name` column) **after** any
+  time update succeeds, and is allowed on **any** phase including ended ones.
+- Net behavior: renaming works on any phase; changing the **time window** of a
+  locked/active phase is still rejected as before.
+
+## Admin sign-off
+
+Pending admin manual verification (stage 3).

--- a/models/hackforger/phase.go
+++ b/models/hackforger/phase.go
@@ -103,6 +103,17 @@ func UpdatePhase(ctx context.Context, p *Phase) error {
 	return err
 }
 
+// UpdatePhaseCustomName updates only the custom_name column of a phase.
+// The name is a cosmetic label independent of the time window, so this writes
+// just that column (and updated_unix) without touching start_time/end_time.
+// An empty string clears the custom name.
+func UpdatePhaseCustomName(ctx context.Context, phaseID int64, name string) error {
+	_, err := db.GetEngine(ctx).ID(phaseID).
+		Cols("custom_name", "updated_unix").
+		Update(&Phase{CustomName: name, UpdatedUnix: timeutil.TimeStampNow()})
+	return err
+}
+
 // DeletePhase deletes a phase by ID.
 func DeletePhase(ctx context.Context, id int64) error {
 	_, err := db.GetEngine(ctx).ID(id).Delete(&Phase{})

--- a/routers/api/v1/hackforger/phase.go
+++ b/routers/api/v1/hackforger/phase.go
@@ -23,10 +23,12 @@ type AddPhaseForm struct {
 }
 
 // UpdatePhaseForm is the form for updating an existing phase.
+// CustomName is a pointer so callers can omit it (leave the name untouched on a
+// time-only edit) vs. send "" to clear it.
 type UpdatePhaseForm struct {
-	StartTime  int64  `json:"start_time" binding:"Required"`
-	EndTime    int64  `json:"end_time" binding:"Required"`
-	CustomName string `json:"custom_name"`
+	StartTime  int64   `json:"start_time" binding:"Required"`
+	EndTime    int64   `json:"end_time" binding:"Required"`
+	CustomName *string `json:"custom_name"`
 }
 
 // ReorderPhasesForm is the form for batch-updating phase sort orders.
@@ -160,28 +162,31 @@ func UpdatePhaseAPI(ctx *context.APIContext) {
 	phaseID := ctx.ParamsInt64(":phase_id")
 	form := web.GetForm(ctx).(*UpdatePhaseForm)
 
-	if err := hackforger_service.UpdatePhaseTime(ctx, phaseID, form.StartTime, form.EndTime); err != nil {
-		if hackforger_service.IsErrPhaseLocked(err) || hackforger_service.IsErrActivePhaseStartLocked(err) {
-			ctx.Error(http.StatusBadRequest, "UpdatePhase", err)
-			return
-		}
-		if hackforger_service.IsErrPhaseOverlap(err) {
-			ctx.Error(http.StatusBadRequest, "UpdatePhase", err)
-			return
-		}
-		ctx.InternalServerError(err)
+	phase, err := hackforger_model.GetPhaseByID(ctx, phaseID)
+	if err != nil || phase == nil {
+		ctx.NotFound()
 		return
 	}
 
-	// Update custom_name if provided
-	if form.CustomName != "" {
-		phase, err := hackforger_model.GetPhaseByID(ctx, phaseID)
-		if err != nil || phase == nil {
+	// The time window is guarded (locked/active phases reject changes). Only run
+	// the guarded path when the times actually change, so a pure rename (incl.
+	// an ended phase) isn't rejected and a failed time update never leaves a
+	// half-applied custom_name behind.
+	if form.StartTime != phase.StartTime || form.EndTime != phase.EndTime {
+		if err := hackforger_service.UpdatePhaseTime(ctx, phaseID, form.StartTime, form.EndTime); err != nil {
+			if hackforger_service.IsErrPhaseLocked(err) || hackforger_service.IsErrActivePhaseStartLocked(err) || hackforger_service.IsErrPhaseOverlap(err) {
+				ctx.Error(http.StatusBadRequest, "UpdatePhase", err)
+				return
+			}
 			ctx.InternalServerError(err)
 			return
 		}
-		phase.CustomName = form.CustomName
-		if err := hackforger_model.UpdatePhase(ctx, phase); err != nil {
+	}
+
+	// The custom name is independent of the time window and can be changed on
+	// any phase. nil = not provided (leave untouched); non-nil sets it, "" clears.
+	if form.CustomName != nil && *form.CustomName != phase.CustomName {
+		if err := hackforger_model.UpdatePhaseCustomName(ctx, phaseID, *form.CustomName); err != nil {
 			ctx.InternalServerError(err)
 			return
 		}
@@ -193,7 +198,7 @@ func UpdatePhaseAPI(ctx *context.APIContext) {
 	}
 
 	// Return the updated phase
-	phase, err := hackforger_model.GetPhaseByID(ctx, phaseID)
+	phase, err = hackforger_model.GetPhaseByID(ctx, phaseID)
 	if err != nil || phase == nil {
 		ctx.InternalServerError(err)
 		return

--- a/routers/web/hackforger/phase.go
+++ b/routers/web/hackforger/phase.go
@@ -112,15 +112,31 @@ func ManagePhasesUpdate(ctx *context.Context) {
 		return
 	}
 
-	// Update custom_name if provided (can be empty string to clear)
-	if phase, _ := hackforger_model.GetPhaseByID(ctx, phaseID); phase != nil {
-		phase.CustomName = req.CustomName
-		_ = hackforger_model.UpdatePhase(ctx, phase)
+	phase, err := hackforger_model.GetPhaseByID(ctx, phaseID)
+	if err != nil || phase == nil {
+		ctx.JSON(http.StatusNotFound, map[string]string{"error": ctx.Locale.TrString("hackforger.phase.error.not_found")})
+		return
 	}
 
-	if err := hackforger_service.UpdatePhaseTime(ctx, phaseID, req.StartTime, req.EndTime); err != nil {
-		handlePhaseError(ctx, err)
-		return
+	// The time window is guarded (locked/active phases reject changes). Only run
+	// the guarded path when the times actually change, so a pure rename of an
+	// ended phase isn't rejected — and so a failed time update never leaves a
+	// half-applied custom_name behind.
+	if req.StartTime != phase.StartTime || req.EndTime != phase.EndTime {
+		if err := hackforger_service.UpdatePhaseTime(ctx, phaseID, req.StartTime, req.EndTime); err != nil {
+			handlePhaseError(ctx, err)
+			return
+		}
+	}
+
+	// The custom name is a cosmetic label independent of the time window, so it
+	// can be changed on any phase (including ended ones). Persisted only after
+	// any time update above succeeded. Empty string clears it.
+	if req.CustomName != phase.CustomName {
+		if err := hackforger_model.UpdatePhaseCustomName(ctx, phaseID, req.CustomName); err != nil {
+			handlePhaseError(ctx, err)
+			return
+		}
 	}
 
 	if syncErr := hackforger_service.SyncStatusCache(ctx, h.ID, ctx.Doer.ID); syncErr != nil {

--- a/routers/web/hackforger/phase.go
+++ b/routers/web/hackforger/phase.go
@@ -103,9 +103,9 @@ func ManagePhasesUpdate(ctx *context.Context) {
 	phaseID := ctx.ParamsInt64("phase_id")
 
 	var req struct {
-		StartTime  int64  `json:"start_time"`
-		EndTime    int64  `json:"end_time"`
-		CustomName string `json:"custom_name"`
+		StartTime  int64   `json:"start_time"`
+		EndTime    int64   `json:"end_time"`
+		CustomName *string `json:"custom_name"`
 	}
 	if err := json.NewDecoder(ctx.Req.Body).Decode(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
@@ -131,9 +131,11 @@ func ManagePhasesUpdate(ctx *context.Context) {
 
 	// The custom name is a cosmetic label independent of the time window, so it
 	// can be changed on any phase (including ended ones). Persisted only after
-	// any time update above succeeded. Empty string clears it.
-	if req.CustomName != phase.CustomName {
-		if err := hackforger_model.UpdatePhaseCustomName(ctx, phaseID, req.CustomName); err != nil {
+	// any time update above succeeded. A nil custom_name means "not provided"
+	// (e.g. a time-only edit) and must leave the existing name untouched; a
+	// non-nil value sets it, where "" clears it.
+	if req.CustomName != nil && *req.CustomName != phase.CustomName {
+		if err := hackforger_model.UpdatePhaseCustomName(ctx, phaseID, *req.CustomName); err != nil {
 			handlePhaseError(ctx, err)
 			return
 		}

--- a/templates/hackforger/hackathon/view.tmpl
+++ b/templates/hackforger/hackathon/view.tmpl
@@ -27,7 +27,7 @@
 		<div class="hf-timeline">
 			{{range .Phases}}
 			<div class="hf-timeline-step {{if .IsLocked}}hf-step-done{{else if .IsActive}}hf-step-active{{else}}hf-step-upcoming{{end}}">
-				<div class="hf-step-name">{{if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
+				<div class="hf-step-name">{{if .CustomName}}{{.CustomName}}{{else if .PhaseType}}{{ctx.Locale.Tr .PhaseType.DisplayNameI18n}}{{end}}</div>
 				<div class="hf-step-date">{{DateUtils.AbsoluteShort .StartTime}} — {{DateUtils.AbsoluteShort .EndTime}}</div>
 				<div class="hf-step-status">
 					{{if .IsLocked}}{{ctx.Locale.Tr "hackforger.hackathon.manage.phase.step.done"}}

--- a/web_src/js/components/hackforger/PhaseTimeline.vue
+++ b/web_src/js/components/hackforger/PhaseTimeline.vue
@@ -233,7 +233,7 @@ export default {
       </template>
       <strong v-else class="tw-min-w-24 tw-max-w-48 tw-truncate tw-flex tw-items-center tw-gap-1">
         {{ phaseTypeName(phase) }}
-        <button v-if="phaseState(phase) !== 'locked'" class="tw-text-gray tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0"
+        <button class="tw-text-gray tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0"
                 @click="startRename(phase)" title="Rename">
           <svg width="14" height="14" viewBox="0 0 16 16"><path fill="currentColor" d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L3.463 11.1a.25.25 0 00-.064.108l-.563 1.97 1.971-.564a.25.25 0 00.108-.064l8.61-8.61a.25.25 0 000-.354l-1.086-1.086z"/></svg>
         </button>


### PR DESCRIPTION
## Fixes #182 — awaiting tester acceptance on internal site before merge

> This re-opens the #182 work as an **open PR** for tester verification on https://hackforger.inside.h2os.cloud before merging to `v0.1-dev`. (The earlier auto-merged #183 was reverted from `v0.1-dev`.)

### 1. Public page render (the reported bug)
`templates/hackforger/hackathon/view.tmpl` — the public timeline ignored an admin-edited phase `custom_name` and always showed the phase type's default i18n name. Now: custom name wins, falls back to the default — mirroring `PhaseTimeline.vue:59`.

### 2. Handler fix — decouple rename from the time-window guard
`routers/web/hackforger/phase.go` previously wrote `custom_name` **unconditionally before** the `UpdatePhaseTime` ended-phase guard, so renaming an **ended** phase persisted the name yet returned `403` (partial write on a failed request). Now:
- the guarded `UpdatePhaseTime` runs **only when start/end actually change**;
- the name is persisted via a focused `UpdatePhaseCustomName` (writes only `custom_name`) **after** any time update succeeds, allowed on **any** phase;
- changing the **time window** of a locked/active phase is still rejected.

### Verification (codex E2E on localhost:3000, real web route)
| Test | Result |
|------|--------|
| render: edited phase shows custom name on public page | PASS |
| render: unedited phase shows default | PASS |
| rename **ended** phase → 200 + persists + shows on page | PASS |
| change **time** of ended phase → 403, **no** partial write | PASS |
| rename non-ended (regression) | PASS |
| clear name | PASS |

Smoke report: `docs/tests/e2e/reports/2026-06-01-phase-custom-name-public-render.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)