### PR TITLE
feat(landing): relabel passed stage buttons to 查看详情 (#188)

### DIFF
--- a/custom/public/assets/landing/index.html
+++ b/custom/public/assets/landing/index.html
@@ -1617,7 +1617,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月10日-5月15日</span>
 </div>
-<button data-stage="s1-w2" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">立即报名</button>
+<button data-stage="s1-w2" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">查看详情</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1629,7 +1629,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月17日-5月24日</span>
 </div>
-<button data-stage="s1-w3" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">即刻报名</button>
+<button data-stage="s1-w3" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">查看详情</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">
@@ -1669,7 +1669,7 @@ window.HACKFORGER_LANDING_CONFIG = {
 <div class="mb-6 flex items-center flex-wrap gap-1.5">
 <span class="inline-flex items-center px-2 py-0.5 bg-[#FFA526] text-black text-[8px] font-black rounded-[2px] font-oppo">5月27日-5月29日</span>
 </div>
-<button data-stage="s2-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">即刻报名</button>
+<button data-stage="s2-w1" class="w-full py-3 bg-primary text-black text-xs md:text-sm font-black rounded-full uppercase tracking-widest hover:scale-[0.98] transition-transform font-oppo mt-auto">查看详情</button>
 </div>
 </div>
 <div class="flex-shrink-0 w-[280px] md:w-[320px] tone-card rounded-lg overflow-hidden flex flex-col relative">


### PR DESCRIPTION
## 落地页更新 6.3 — 赛段按钮随日期归位（#188）

S1W2 / S1W3 / S2W1 的报名窗口都已结束(日期角标 `5月10日-5月15日` / `5月17日-5月24日` / `5月27日-5月29日`,今天 6月3日),按钮从 **Open → Passed** 状态:

| 卡片 | 角标 | Before | After |
|---|---|---|---|
| S1 复赛W2 数智OPC | 5月10日-5月15日 | `立即报名` | **`查看详情`** |
| S1 半决赛W3 数智OPC | 5月17日-5月24日 | `即刻报名` | **`查看详情`** |
| S2 初赛W1 跨境OPC | 5月27日-5月29日 | `即刻报名` | **`查看详情`** |

- **纯文案改动**:按钮保持绿色可点(`bg-primary`,`enabled:true`),仅换文案 —— 与已经处于该状态的 **S1初赛W1** 一致。报名已截止但赛段页仍在,点击仍跳转 `/hackathon/<slug>` 查看详情。
- i18n `查看详情→View Details` 已存在,**无需改词典**;`HACKFORGER_LANDING_CONFIG.stages` 无需改动。
- 未动其它卡片:S2W2/W3 仍 `即刻报名`(报名进行中),S1W4 仍灰色决赛态。

### 本地验证
review 阶段已用 headless 截图(decode 后再截)确认:中文三张卡均为绿色可点 **「查看详情」**;英文(`?lang=en`)同三张显示 **「View Details」**(i18n 未回退);banner 正常,diff 仅 3 行。

### 测试
- 静态资源改动(`custom/public`,磁盘直读),无需 `make`。
- E2E 烟雾测试 + prod 部署按 gitflow,合并到 dev 后补。

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
