### PR TITLE
fix(security): keep boundary guard self-clean

### DIFF
--- a/scripts/ci/check_public_repository_boundary.py
+++ b/scripts/ci/check_public_repository_boundary.py
@@ -213,7 +213,7 @@ IPV6_EXEMPT_HASHES = {
 }
 PERSONAL_PATH_EXEMPT_HASHES = {
     # Whole-file hashes pin reviewed upstream API routes, templates, fixtures,
-    # and examples whose lowercase `/users/...` text is not a local home path.
+    # and examples whose lowercase API user-route text is not a local home path.
     "contrib/launchd/io.gitea.web.plist": "724667b726d366ae48c8c626f1870bf143249df66bb1fa7f9f8ab4d0e43f2fbc",
     "docs/product/user-journeys/hacker-social.md": "16c7bb7518269a8bbb68b528bac2f99c18680b5e4de0af9e9f0efbbc09c29db2",
     "docs/product/user-journeys/platform-bot.md": "2381402fae472190b6dd9e2af56654724cedfb08a10ef797bdf58db079430921",

--- a/scripts/ci/test_public_repository_boundary.py
+++ b/scripts/ci/test_public_repository_boundary.py
@@ -491,7 +491,7 @@ class BoundaryCheckerTest(unittest.TestCase):
         self.write("deploy/example.md", "root=/" + "Users/alice\n")
         self.assertIn("PERSONAL_PATH", self.run_checker().stderr)
 
-        self.write("deploy/example.md", "root=/users/alice/work\n")
+        self.write("deploy/example.md", "root=/" + "users/alice/work\n")
         self.assertIn("PERSONAL_PATH", self.run_checker().stderr)
 
     def test_internal_host_fails_but_locale_key_passes(self) -> None:
@@ -501,10 +501,11 @@ class BoundaryCheckerTest(unittest.TestCase):
         self.assertIn("INTERNAL_HOST\tdocs/host.md", result.stderr)
 
         locale_key = "hackathon.error." + "internal"
+        short_locale_key = "desc." + "internal"
         self.write(
             "options/locale/test.ini",
             f"{locale_key} = Generic error.\n"
-            "desc.internal = Internal\n",
+            f"{short_locale_key} = Internal\n",
         )
         subprocess.run(
             ["git", "-C", str(self.root), "rm", "-f", "docs/host.md"],
@@ -546,17 +547,18 @@ class BoundaryCheckerTest(unittest.TestCase):
         self.assertEqual(0, self.run_checker().returncode)
 
     def test_internal_like_values_outside_locales_still_fail(self) -> None:
+        suffix = "internal"
         self.write(
             "docs/locale-keys.md",
-            "desc.internal = Internal\n"
-            "bounty.error.internal = Generic error.\n",
+            f"desc.{suffix} = Internal\n"
+            f"bounty.error.{suffix} = Generic error.\n",
         )
-        self.write("modules/example.go", "return q.internal.Load()\n")
+        self.write("modules/example.go", f"return q.{suffix}.Load()\n")
         result = self.run_checker()
         self.assertIn("INTERNAL_HOST\tdocs/locale-keys.md", result.stderr)
         self.assertIn("INTERNAL_HOST\tmodules/example.go", result.stderr)
 
-        self.write("docs/host.md", "cert=/etc/db." + "internal.pem\n")
+        self.write("docs/host.md", f"cert=/etc/db.{suffix}.pem\n")
         self.assertIn("INTERNAL_HOST\tdocs/host.md", self.run_checker().stderr)
 
     def test_single_label_internal_host_and_sensitive_path_parts_fail(self) -> None:


### PR DESCRIPTION
## Summary

Prevent the boundary guard and its tests from matching their own fixture literals.

- replace one explanatory literal with neutral wording;
- construct sensitive test fixtures at runtime, as the existing tests already do elsewhere;
- keep every positive/negative assertion and checker behavior unchanged.

## Verification

- `53` complete boundary tests passed;
- both guard source files pass targeted content scanning;
- independent static review found no P0/P1/P2 and confirmed the runtime fixture bytes are unchanged;
- `git diff --check` passed.

## Guard update exception

This is a dedicated two-file guard update. Its branch was pushed with the required audited `--no-verify` exception. The trusted guard-integrity step is expected to reject it until an explicit security-admin merge. Reinstall the immutable hook after merge.
